### PR TITLE
Split CI pipeline into multiple jobs

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,6 +1,14 @@
 name: Scala with Gradle CI
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   StyleCheck:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,17 +1,38 @@
 name: Scala with Gradle CI
 
-on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
+  StyleCheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The project uses java 11 (LTS) with scala 2.13
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      # Use cache if available for Gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Check Scala formatting with Spotless
+        run: ./gradlew spotlessCheck
+
   Build:
+    # The matrix runs only if the scala style is correct
+    needs: StyleCheck
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -39,5 +60,33 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build and Test with Gradle
-        run: ./gradlew build
+      - name: Assemble Scala sources with Gradle
+        run: ./gradlew assemble
+
+  Tests:
+    runs-on: ubuntu-latest
+    needs: [StyleCheck, Build]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The project uses java 11 (LTS) with scala 2.13
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      # Use cache if available for Gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Check and tests with Gradle
+        run: ./gradlew check


### PR DESCRIPTION
Working on #11. I created three separate jobs:

- the first one with a single Ubuntu machine, checks the Scala style of the project with Spotless;
- the second one, with a OS matrix, tries to compile the Scala code (without tests and checks), with `./gradlew assemble`. Executed only if the first job succeeds;
- the third one, with a single Ubuntu machine, executes `./gradlew check` (executing tests and other checks). Executed only if the two first jobs succeeds.