### PR TITLE
Switch from Spotless to gradle-scalafmt, new code conventions

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -24,17 +24,6 @@ jobs:
         with:
           java-version: 11
 
-      # Use cache if available for Gradle
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Check Scala formatting with Spotless
         run: ./gradlew checkScalafmtAll
 
@@ -57,17 +46,6 @@ jobs:
         with:
           java-version: 11
 
-      # Use cache if available for Gradle
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
       - name: Assemble Scala sources with Gradle
         run: ./gradlew assemble
 
@@ -84,17 +62,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-
-      # Use cache if available for Gradle
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Check and Test with Gradle
         run: ./gradlew check

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -36,9 +36,9 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Check Scala formatting with Spotless
-        run: ./gradlew spotlessCheck
+        run: ./gradlew checkScalafmtAll
 
-  Build:
+  Compile:
     # The matrix runs only if the scala style is correct
     needs: StyleCheck
     runs-on: ${{ matrix.os }}
@@ -71,9 +71,9 @@ jobs:
       - name: Assemble Scala sources with Gradle
         run: ./gradlew assemble
 
-  Tests:
+  Test:
     runs-on: ubuntu-latest
-    needs: [StyleCheck, Build]
+    needs: [StyleCheck, Compile]
 
     steps:
       - name: Checkout repository
@@ -96,5 +96,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Check and tests with Gradle
+      - name: Check and Test with Gradle
         run: ./gradlew check

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,42 @@
 version = 2.7.5
-maxColumn = 100
+
+maxColumn = 120
+
+// Pretty alignment preset for various things
+// align.preset = more
+
+// indented by 2 (default)
+continuationIndent.callSite = 2
+
+// indentation of function definitions body. Default to 4
+continuationIndent.defnSite = 4
+
+// indentation of a new line <extends>
+continuationIndent.extendSite = 4
+
+// default, whether to indent arguments to open parens
+align.openParenCallSite = false
+
+// default, whether to indent arguments to open parens
+align.openParenDefnSite = false
+
+// lets arguments inline, if possible
+optIn.configStyleArguments = true
+
+// attempts to preserve line breaks in the input whenever possible
+newlines.source=keep
+
+// experimental, attempts to remove line breaks whenever possible resulting in a more horizontal,
+// or vertically compact look
+// newlines.source=fold,unfold
+
+// whether closing parens are put in the same line of the last arg, or in a new line. Default to true (new line)
+// danglingParentheses.defnSite = false
+// danglingParentheses.callSite = false
+
+// Forces dangling on open/close parens around control structures (if, while, for) when line breaks must occur
+// danglingParentheses.ctrlSite = true
+
+// controls whether to enforce a blank line before and/or after a top-level statement spanning a certain
+// number of lines
+// newlines.topLevelStatements = [before]

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation("org.danilopianini:git-sensitive-semantic-versioning:_")
     implementation("org.danilopianini:publish-on-central:_")
     implementation("com.github.maiflai:gradle-scalatest:_")
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:_")
+    implementation("gradle.plugin.cz.alenkacz:gradle-scalafmt:_")
 
     // Makes Detekt configurable
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:_")

--- a/buildSrc/src/main/kotlin/scalaquest.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.common-conventions.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     id("com.github.maiflai.scalatest")
 
     // A scala linter-formatter
-    id("com.diffplug.spotless")
+    id("cz.alenkacz.gradle.scalafmt")
 }
 
 repositories {
@@ -26,12 +26,8 @@ gitSemVer {
     version = computeGitSemVer()
 }
 
-spotless {
-    scala {
-        // by default, all `.scala` and `.sc` files in the java sourcesets will be formatted
-
-        scalafmt() // has its own section below
-    }
+scalafmt {
+    configFilePath = rootDir.absolutePath + "/.scalafmt.conf"
 }
 
 dependencies {

--- a/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
+++ b/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
@@ -13,44 +13,29 @@ object CLI {
 
   type State = Model#State
 
-  def printNotifications(
-      pusher: MessagePusher
-  )(messages: Seq[Message]): String =
+  def printNotifications(pusher: MessagePusher)(messages: Seq[Message]): String =
     pusher(messages) reduceOption (_ + "\n" + _) getOrElse ""
 
-  def startGame[S <: State](
-      game: Game[S],
-      pusher: MessagePusher
-  )(state: S): ZIO[Console, Exception, Unit] =
+  def startGame[S <: State](game: Game[S], pusher: MessagePusher)(state: S): ZIO[Console, Exception, Unit] =
     for {
       _ <- putStrLn(printNotifications(pusher)(state.messages))
       _ <- gameLoop(game, pusher)(state)
     } yield ()
 
-  def gameLoop[S <: State](
-      game: Game[S],
-      pusher: MessagePusher
-  )(state: S): ZIO[Console, Exception, Unit] =
+  def gameLoop[S <: State](game: Game[S], pusher: MessagePusher)(state: S): ZIO[Console, Exception, Unit] =
     for {
       input <- getStrLn
       res <- UIO.succeed((game send input)(state))
       (out, nextState) <- UIO.succeed(res match {
-        case Left(err) => (err, state)
-        case Right(updated) =>
-          (printNotifications(pusher)(updated.messages), updated)
+        case Left(err)      => (err, state)
+        case Right(updated) => (printNotifications(pusher)(updated.messages), updated)
       })
       _ <- putStrLn(out)
-      _ <- if (!nextState.game.ended)
-        UIO.succeed(nextState) flatMap gameLoop(game, pusher)
-      else ZIO.unit
+      _ <- if (!nextState.game.ended) UIO.succeed(nextState) flatMap gameLoop(game, pusher) else ZIO.unit
     } yield ()
 
-  def apply[S <: State](
-      state: S,
-      game: Game[S],
-      pusher: MessagePusher
-  ): CLI = new CLI {
-    override def start: ZIO[Console, Exception, Unit] =
-      startGame(game, pusher)(state)
-  }
+  def apply[S <: State](state: S, game: Game[S], pusher: MessagePusher): CLI =
+    new CLI {
+      override def start: ZIO[Console, Exception, Unit] = startGame(game, pusher)(state)
+    }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/Game.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/Game.scala
@@ -8,21 +8,16 @@ trait Game[S <: Model#State] {
 }
 
 trait GameTemplate[S <: Model#State] extends Game[S] {
-
   def pipelineFactory(state: S): Pipeline[S]
 
   override def send(input: String)(state: S): Either[String, S] =
     pipelineFactory(state) run input
 }
 
-trait MessagePusher extends (Seq[Message] => Seq[String])
-
 object Game {
-
-  def apply[S <: Model#State](
-      _pipelineFactory: S => Pipeline[S]
-  ): Game[S] = new GameTemplate[S] {
-    override def pipelineFactory(state: S): Pipeline[S] =
-      _pipelineFactory(state)
+  def apply[S <: Model#State](_pipelineFactory: S => Pipeline[S]): Game[S] = new GameTemplate[S] {
+    override def pipelineFactory(state: S): Pipeline[S] = _pipelineFactory(state)
   }
 }
+
+trait MessagePusher extends (Seq[Message] => Seq[String])

--- a/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
@@ -5,33 +5,26 @@ trait Message
 trait Model {
 
   type S <: State
-
   type I <: Item
-
   type Update = S => S
 
   trait State { self: S =>
     def game: GameState
-
     def messages: Seq[Message]
   }
 
   trait GameState {
     def player: Player
-
     def ended: Boolean
   }
 
   trait Player {
     def bag: Set[I]
-
     def location: Room
   }
 
   trait Item { item: I =>
-
     def name: String
-
     def use(action: Action): Option[Update]
   }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
@@ -4,25 +4,16 @@ import io.github.scalaquest.core.model.Direction.Direction
 
 object Direction extends Enumeration {
   type Direction = Value
-
   val NORTH, SOUTH, WEST, EAST, UP, DOWN = Value
 }
 
 trait Room {
-
   def name: String
-
   def describe: String
-
   def neighbors(direction: Direction): Option[Room]
 }
 
-case class SimpleRoom(
-    name: String,
-    _neighbors: () => Map[Direction, Room]
-) extends Room {
+case class SimpleRoom(name: String, _neighbors: () => Map[Direction, Room]) extends Room {
   override def describe: String = s"inspect: ${name}"
-
-  override def neighbors(direction: Direction): Option[Room] =
-    _neighbors() get direction
+  override def neighbors(direction: Direction): Option[Room] = _neighbors() get direction
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
@@ -8,24 +8,13 @@ object SimpleModel extends Model {
   override type S = SimpleState
   override type I = SimpleItem
 
-  case class SimpleItem(
-      name: String
-  ) extends Item {
+  case class SimpleItem(name: String) extends Item {
     override def use(action: Action): Option[Update] = Some(x => x)
   }
 
-  case class SimplePlayer(
-      bag: Set[SimpleItem],
-      location: Room
-  ) extends Player
+  case class SimplePlayer(bag: Set[SimpleItem], location: Room) extends Player
 
-  case class SimpleGameState(
-      player: SimplePlayer,
-      ended: Boolean
-  ) extends GameState
+  case class SimpleGameState(player: SimplePlayer, ended: Boolean) extends GameState
 
-  case class SimpleState(
-      game: SimpleGameState,
-      messages: Seq[Message]
-  ) extends State
+  case class SimpleState(game: SimpleGameState, messages: Seq[Message]) extends State
 }

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
@@ -8,9 +8,7 @@ trait InterpreterResult {
 }
 
 trait Interpreter[S <: Model#State] {
-  def interpret(
-      resolverResult: ResolverResult
-  ): Either[String, InterpreterResult]
+  def interpret(resolverResult: ResolverResult): Either[String, InterpreterResult]
 }
 
 object Interpreter {

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
@@ -6,15 +6,10 @@ sealed trait AST
 
 object AST {
   final case class Intransitive(verb: String, subject: String) extends AST
-  final case class Transitive(verb: String, subject: String, target: String)
-      extends AST
+  final case class Transitive(verb: String, subject: String, target: String) extends AST
+
   // TODO: https://it.wikipedia.org/wiki/Verbo_ditransitivo
-  final case class Ditransitive(
-      verb: String,
-      subject: String,
-      target1: String,
-      target2: String
-  ) extends AST
+  final case class Ditransitive(verb: String, subject: String, target1: String, target2: String) extends AST
 
   // Transitive("get", "you", "key")
 }

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
@@ -1,25 +1,14 @@
 package io.github.scalaquest.core.pipeline.resolver
 
-import io.github.scalaquest.core.model.{
-  Action,
-  DitransitiveAction,
-  IntransitiveAction,
-  Model,
-  TransitiveAction
-}
+import io.github.scalaquest.core.model.{Action, DitransitiveAction, IntransitiveAction, Model, TransitiveAction}
 import io.github.scalaquest.core.pipeline.parser.{AST, ParserResult}
 
 sealed trait Statement
 
 object Statement {
   final case class Intransitive(action: IntransitiveAction) extends Statement
-  final case class Transitive(action: TransitiveAction, target: Model#Item)
-      extends Statement
-  final case class Ditransitive(
-      action: DitransitiveAction,
-      target1: Model#Item,
-      target2: Model#Item
-  ) extends Statement
+  final case class Transitive(action: TransitiveAction, target: Model#Item) extends Statement
+  final case class Ditransitive(action: DitransitiveAction, target1: Model#Item, target2: Model#Item) extends Statement
 }
 
 trait ResolverResult {

--- a/versions.properties
+++ b/versions.properties
@@ -9,8 +9,6 @@ plugin.io.gitlab.arturbosch.detekt=1.15.0-RC1
 ##                     # available=1.15.0-RC2
 ##                     # available=1.15.0
 
-version.com.diffplug.spotless..spotless-plugin-gradle=5.8.2
-
 version.com.github.maiflai..gradle-scalatest=0.30
 
 version.com.vladsch.flexmark..flexmark-all=0.35.10
@@ -85,6 +83,8 @@ version.com.vladsch.flexmark..flexmark-all=0.35.10
 
 version.dev.zio..zio_2.13=1.0.3
 
+version.gradle.plugin.cz.alenkacz..gradle-scalafmt=1.14.0
+
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 
 version.it.unibo.alice.tuprolog..tuprolog=3.3.0
@@ -110,33 +110,3 @@ version.org.scala-lang..scala-library=2.13.3
 version.org.scalatest..scalatest_2.13=3.2.3
 ##                        # available=3.3.0-SNAP2
 ##                        # available=3.3.0-SNAP3
-
-version.org.typelevel..cats-effect_2.13=2.2.0
-##                          # available=2.3.0-M1
-##                          # available=2.3.0
-##                          # available=2.3.1
-##                          # available=3.0-0c02c7f
-##                          # available=3.0-3f2b25c
-##                          # available=3.0-8a09def
-##                          # available=3.0-c54025b
-##                          # available=3.0-cee70ab
-##                          # available=3.0-d2cb13e
-##                          # available=3.0-f5eba3c
-##                          # available=3.0-f6fe01c
-##                          # available=3.0-80f5cc5
-##                          # available=3.0-87c19b5
-##                          # available=3.0-ac83d13
-##                          # available=3.0-805b021
-##                          # available=3.0-f471c52
-##                          # available=3.0-bb20d55
-##                          # available=3.0-26ef642
-##                          # available=3.0-64ae949
-##                          # available=3.0-de7d987
-##                          # available=3.0-d5a2213
-##                          # available=3.0.0-M1
-##                          # available=3.0.0-M2
-##                          # available=3.0.0-M3
-##                          # available=3.0.0-M4
-##                          # available=3.0-137-0edddb5
-##                          # available=3.0-8006968
-##                          # available=3.0-8096649


### PR DESCRIPTION
These modifications bring the [gradle-scalafmt](https://github.com/alenkacz/gradle-scalafmt) formatter into the project, and adds some modifications to the .scalafmt.conf, adapting the style to our preferred one.

With regards to the new plugin, these are the main difference from Spotless:
- Format check **is not launched automatically** with the build task. This could be seen as an advantage or disadvantage, based on the point of view. In my opinion, it is an advantage, as gives us more control in when to launch the format check (I set it to be launched before the compilation, in CI, for example);
- `spotlessCheck` task becomes `checkScalafmtAll`
- `spotlessApply` task becomes `scalafmtAll`

With regards to the new code conventions, these are the main difference from scalafmt default:
- **max column** is now set to 120 (IntelliJ default for Scala)
- overall configuration **favors "horizontal" code**, allowing to do when possible inline operation. When not possible for excessive line size, it formats the code accordingly (but only in that case, not always as before)
- formatter **tends to not force blank newlines** (for example, before or after function definitions). This can be discussed, but experimentally, leaving freedom to the programmer for this point leads to more readable code.