### PR TITLE
Stay with Spotless, new code conventions

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check Scala formatting with Spotless
         run: ./gradlew spotlessCheck
 
-  Build:
+  Compile:
     # The matrix runs only if the scala style is correct
     needs: StyleCheck
     runs-on: ${{ matrix.os }}
@@ -71,9 +71,9 @@ jobs:
       - name: Assemble Scala sources with Gradle
         run: ./gradlew assemble
 
-  Tests:
+  Test:
     runs-on: ubuntu-latest
-    needs: [StyleCheck, Build]
+    needs: [StyleCheck, Compile]
 
     steps:
       - name: Checkout repository
@@ -96,5 +96,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Check and tests with Gradle
+      - name: Check and Test with Gradle
         run: ./gradlew check

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -39,4 +39,16 @@ newlines.source=keep
 
 // controls whether to enforce a blank line before and/or after a top-level statement spanning a certain
 // number of lines
-// newlines.topLevelStatements = [before]
+newlines.topLevelStatements = [before]
+
+// 0 applies space to all top-level statements, 1 applies only multi line statements (default)
+newlines.topLevelStatementsMinBreaks=1
+
+// line break after '=' for multiline definitions
+newlines.beforeMultilineDef = unfold
+
+// scaladoc asterisk formatting
+docstrings.style = Asterisk
+
+
+

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,7 @@ version = 2.7.5
 maxColumn = 120
 
 // Pretty alignment preset for various things
-// align.preset = more
+align.preset = more
 
 // indented by 2 (default)
 continuationIndent.callSite = 2

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,42 @@
 version = 2.7.5
-maxColumn = 100
+
+maxColumn = 120
+
+// Pretty alignment preset for various things
+// align.preset = more
+
+// indented by 2 (default)
+continuationIndent.callSite = 2
+
+// indentation of function definitions body. Default to 4
+continuationIndent.defnSite = 4
+
+// indentation of a new line <extends>
+continuationIndent.extendSite = 4
+
+// default, whether to indent arguments to open parens
+align.openParenCallSite = false
+
+// default, whether to indent arguments to open parens
+align.openParenDefnSite = false
+
+// lets arguments inline, if possible
+optIn.configStyleArguments = true
+
+// attempts to preserve line breaks in the input whenever possible
+newlines.source=keep
+
+// experimental, attempts to remove line breaks whenever possible resulting in a more horizontal,
+// or vertically compact look
+// newlines.source=fold,unfold
+
+// whether closing parens are put in the same line of the last arg, or in a new line. Default to true (new line)
+// danglingParentheses.defnSite = false
+// danglingParentheses.callSite = false
+
+// Forces dangling on open/close parens around control structures (if, while, for) when line breaks must occur
+// danglingParentheses.ctrlSite = true
+
+// controls whether to enforce a blank line before and/or after a top-level statement spanning a certain
+// number of lines
+// newlines.topLevelStatements = [before]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,10 +9,10 @@ align.preset = more
 continuationIndent.callSite = 2
 
 // indentation of function definitions body. Default to 4
-continuationIndent.defnSite = 4
+continuationIndent.defnSite = 2
 
 // indentation of a new line <extends>
-continuationIndent.extendSite = 4
+continuationIndent.extendSite = 2
 
 // default, whether to indent arguments to open parens
 align.openParenCallSite = false

--- a/buildSrc/src/main/kotlin/scalaquest.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.common-conventions.gradle.kts
@@ -28,9 +28,7 @@ gitSemVer {
 
 spotless {
     scala {
-        // by default, all `.scala` and `.sc` files in the java sourcesets will be formatted
-
-        scalafmt() // has its own section below
+        scalafmt("2.7.5").configFile(rootDir.absolutePath + "/.scalafmt.conf")
     }
 }
 

--- a/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
+++ b/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
@@ -24,17 +24,13 @@ object CLI {
   def gameLoop[S <: State](game: Game[S], pusher: MessagePusher)(state: S): ZIO[Console, Exception, Unit] =
     for {
       input <- getStrLn
-      res <- UIO.succeed((game send input)(state))
+      res   <- UIO.succeed((game send input)(state))
       (out, nextState) <- UIO.succeed(res match {
-        case Left(err) => (err, state)
-        case Right(updated) =>
-          (printNotifications(pusher)(updated.messages), updated)
+        case Left(err)      => (err, state)
+        case Right(updated) => (printNotifications(pusher)(updated.messages), updated)
       })
       _ <- putStrLn(out)
-      _ <-
-        if (!nextState.game.ended)
-          UIO.succeed(nextState) flatMap gameLoop(game, pusher)
-        else ZIO.unit
+      _ <- if (!nextState.game.ended) UIO.succeed(nextState) flatMap gameLoop(game, pusher) else ZIO.unit
     } yield ()
 
   def apply[S <: State](state: S, game: Game[S], pusher: MessagePusher): CLI =

--- a/core/src/main/scala/io/github/scalaquest/core/Game.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/Game.scala
@@ -15,9 +15,9 @@ trait GameTemplate[S <: Model#State] extends Game[S] {
 trait MessagePusher extends (Seq[Message] => Seq[String])
 
 object Game {
+
   def apply[S <: Model#State](_pipelineFactory: S => Pipeline[S]): Game[S] =
     new GameTemplate[S] {
-      override def pipelineFactory(state: S): Pipeline[S] =
-        _pipelineFactory(state)
+      override def pipelineFactory(state: S): Pipeline[S] = _pipelineFactory(state)
     }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/Game.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/Game.scala
@@ -8,21 +8,16 @@ trait Game[S <: Model#State] {
 }
 
 trait GameTemplate[S <: Model#State] extends Game[S] {
-
   def pipelineFactory(state: S): Pipeline[S]
-
-  override def send(input: String)(state: S): Either[String, S] =
-    pipelineFactory(state) run input
+  override def send(input: String)(state: S): Either[String, S] = pipelineFactory(state) run input
 }
 
 trait MessagePusher extends (Seq[Message] => Seq[String])
 
 object Game {
-
-  def apply[S <: Model#State](
-      _pipelineFactory: S => Pipeline[S]
-  ): Game[S] = new GameTemplate[S] {
-    override def pipelineFactory(state: S): Pipeline[S] =
-      _pipelineFactory(state)
-  }
+  def apply[S <: Model#State](_pipelineFactory: S => Pipeline[S]): Game[S] =
+    new GameTemplate[S] {
+      override def pipelineFactory(state: S): Pipeline[S] =
+        _pipelineFactory(state)
+    }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/Action.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Action.scala
@@ -3,5 +3,5 @@ package io.github.scalaquest.core.model
 sealed trait Action
 
 trait IntransitiveAction extends Action
-trait TransitiveAction extends Action
+trait TransitiveAction   extends Action
 trait DitransitiveAction extends Action

--- a/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
@@ -5,33 +5,26 @@ trait Message
 trait Model {
 
   type S <: State
-
   type I <: Item
-
   type Update = S => S
 
   trait State { self: S =>
     def game: GameState
-
     def messages: Seq[Message]
   }
 
   trait GameState {
     def player: Player
-
     def ended: Boolean
   }
 
   trait Player {
     def bag: Set[I]
-
     def location: Room
   }
 
   trait Item { item: I =>
-
     def name: String
-
     def use(action: Action): Option[Update]
   }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
@@ -4,25 +4,16 @@ import io.github.scalaquest.core.model.Direction.Direction
 
 object Direction extends Enumeration {
   type Direction = Value
-
   val NORTH, SOUTH, WEST, EAST, UP, DOWN = Value
 }
 
 trait Room {
-
   def name: String
-
   def describe: String
-
   def neighbors(direction: Direction): Option[Room]
 }
 
-case class SimpleRoom(
-    name: String,
-    _neighbors: () => Map[Direction, Room]
-) extends Room {
+case class SimpleRoom(name: String, _neighbors: () => Map[Direction, Room]) extends Room {
   override def describe: String = s"inspect: ${name}"
-
-  override def neighbors(direction: Direction): Option[Room] =
-    _neighbors() get direction
+  override def neighbors(direction: Direction): Option[Room] = _neighbors() get direction
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Room.scala
@@ -14,6 +14,6 @@ trait Room {
 }
 
 case class SimpleRoom(name: String, _neighbors: () => Map[Direction, Room]) extends Room {
-  override def describe: String = s"inspect: ${name}"
+  override def describe: String                              = s"inspect: ${name}"
   override def neighbors(direction: Direction): Option[Room] = _neighbors() get direction
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
@@ -8,24 +8,13 @@ object SimpleModel extends Model {
   override type S = SimpleState
   override type I = SimpleItem
 
-  case class SimpleItem(
-      name: String
-  ) extends Item {
+  case class SimpleItem(name: String) extends Item {
     override def use(action: Action): Option[Update] = Some(x => x)
   }
 
-  case class SimplePlayer(
-      bag: Set[SimpleItem],
-      location: Room
-  ) extends Player
+  case class SimplePlayer(bag: Set[SimpleItem], location: Room) extends Player
 
-  case class SimpleGameState(
-      player: SimplePlayer,
-      ended: Boolean
-  ) extends GameState
+  case class SimpleGameState(player: SimplePlayer, ended: Boolean) extends GameState
 
-  case class SimpleState(
-      game: SimpleGameState,
-      messages: Seq[Message]
-  ) extends State
+  case class SimpleState(game: SimpleGameState, messages: Seq[Message]) extends State
 }

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/Pipeline.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/Pipeline.scala
@@ -12,19 +12,20 @@ trait Pipeline[S <: Model#State] {
 }
 
 object Pipeline {
+
   def apply[S <: Model#State](
-      lexer: Lexer,
-      parser: Parser,
-      resolver: Resolver,
-      interpreterFactory: S => Interpreter[S],
-      reducerFactory: S => Reducer[S]
+    lexer: Lexer,
+    parser: Parser,
+    resolver: Resolver,
+    interpreterFactory: S => Interpreter[S],
+    reducerFactory: S => Reducer[S]
   )(state: S): Pipeline[S] =
     (rawSentence: String) =>
       for {
-        lr <- (lexer tokenize rawSentence) toRight "Couldn't understand input."
-        pr <- (parser parse lr) toRight "Couldn't understand input."
-        rr <- resolver resolve pr
-        ir <- interpreterFactory(state) interpret rr
+        lr  <- (lexer tokenize rawSentence) toRight "Couldn't understand input."
+        pr  <- (parser parse lr) toRight "Couldn't understand input."
+        rr  <- resolver resolve pr
+        ir  <- interpreterFactory(state) interpret rr
         rdr <- Right(reducerFactory(state) reduce ir)
       } yield rdr.state
 }

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
@@ -8,9 +8,7 @@ trait InterpreterResult {
 }
 
 trait Interpreter[S <: Model#State] {
-  def interpret(
-      resolverResult: ResolverResult
-  ): Either[String, InterpreterResult]
+  def interpret(resolverResult: ResolverResult): Either[String, InterpreterResult]
 }
 
 object Interpreter {

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
@@ -5,11 +5,11 @@ import io.github.scalaquest.core.pipeline.lexer.LexerResult
 sealed trait AST
 
 object AST {
-  final case class Intransitive(verb: String, subject: String) extends AST
-  final case class Transitive(verb: String, subject: String, target: String) extends AST
-  // TODO: https://it.wikipedia.org/wiki/Verbo_ditransitivo
-  final case class Ditransitive(verb: String, subject: String, target1: String, target2: String) extends AST
+  // https://it.wikipedia.org/wiki/Verbo_ditransitivo
   // Transitive("get", "you", "key")
+  final case class Intransitive(verb: String, subject: String)                                   extends AST
+  final case class Transitive(verb: String, subject: String, target: String)                     extends AST
+  final case class Ditransitive(verb: String, subject: String, target1: String, target2: String) extends AST
 }
 
 trait ParserResult {

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/Parser.scala
@@ -6,16 +6,9 @@ sealed trait AST
 
 object AST {
   final case class Intransitive(verb: String, subject: String) extends AST
-  final case class Transitive(verb: String, subject: String, target: String)
-      extends AST
+  final case class Transitive(verb: String, subject: String, target: String) extends AST
   // TODO: https://it.wikipedia.org/wiki/Verbo_ditransitivo
-  final case class Ditransitive(
-      verb: String,
-      subject: String,
-      target1: String,
-      target2: String
-  ) extends AST
-
+  final case class Ditransitive(verb: String, subject: String, target1: String, target2: String) extends AST
   // Transitive("get", "you", "key")
 }
 

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
@@ -6,8 +6,8 @@ import io.github.scalaquest.core.pipeline.parser.{AST, ParserResult}
 sealed trait Statement
 
 object Statement {
-  final case class Intransitive(action: IntransitiveAction) extends Statement
-  final case class Transitive(action: TransitiveAction, target: Model#Item) extends Statement
+  final case class Intransitive(action: IntransitiveAction)                                           extends Statement
+  final case class Transitive(action: TransitiveAction, target: Model#Item)                           extends Statement
   final case class Ditransitive(action: DitransitiveAction, target1: Model#Item, target2: Model#Item) extends Statement
 }
 

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
@@ -1,25 +1,14 @@
 package io.github.scalaquest.core.pipeline.resolver
 
-import io.github.scalaquest.core.model.{
-  Action,
-  DitransitiveAction,
-  IntransitiveAction,
-  Model,
-  TransitiveAction
-}
+import io.github.scalaquest.core.model.{Action, DitransitiveAction, IntransitiveAction, Model, TransitiveAction}
 import io.github.scalaquest.core.pipeline.parser.{AST, ParserResult}
 
 sealed trait Statement
 
 object Statement {
   final case class Intransitive(action: IntransitiveAction) extends Statement
-  final case class Transitive(action: TransitiveAction, target: Model#Item)
-      extends Statement
-  final case class Ditransitive(
-      action: DitransitiveAction,
-      target1: Model#Item,
-      target2: Model#Item
-  ) extends Statement
+  final case class Transitive(action: TransitiveAction, target: Model#Item) extends Statement
+  final case class Ditransitive(action: DitransitiveAction, target1: Model#Item, target2: Model#Item) extends Statement
 }
 
 trait ResolverResult {
@@ -33,10 +22,7 @@ trait Resolver {
 }
 
 trait ResolverFactory {
-  def create(
-      actions: Map[String, Action],
-      items: Map[String, Model#Item]
-  ): Resolver
+  def create(actions: Map[String, Action], items: Map[String, Model#Item]): Resolver
 }
 
 //trait ResolverTemplate extends Resolver {

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/App.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/App.scala
@@ -11,7 +11,5 @@ import io.github.scalaquest.core._
 trait EscapeRoom
 
 object App {
-  def main(args: Array[String]): Unit = {
-    println("Hello Viroli!")
-  }
+  def main(args: Array[String]): Unit = println("Hello Viroli!")
 }

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/App2.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/App2.scala
@@ -14,48 +14,25 @@ object Model {
   case object GameStarted extends Message
   case object TestMessage extends Message
 
-  def room1: Room = SimpleRoom(
-    "room1",
-    () =>
-      Map(
-        NORTH -> room2
-      )
-  )
-  def room2: Room = SimpleRoom(
-    "room2",
-    () =>
-      Map(
-        SOUTH -> room1
-      )
-  )
+  def room1: Room = SimpleRoom("room1", () => Map(NORTH -> room2))
+  def room2: Room = SimpleRoom("room2", () => Map(SOUTH -> room1))
 
   val state: SimpleState = SimpleState(
-    game = SimpleGameState(
-      player = SimplePlayer(
-        bag = Set(),
-        location = room1
-      ),
-      ended = false
-    ),
+    game = SimpleGameState(player = SimplePlayer(bag = Set(), location = room1), ended = false),
     messages = Seq(GameStarted)
   )
 
-  def gameLens: Lens[SimpleState, SimpleGameState] =
-    GenLens[SimpleState](_.game)
-  def playerLens: Lens[SimpleGameState, SimplePlayer] =
-    GenLens[SimpleGameState](_.player)
+  def gameLens: Lens[SimpleState, SimpleGameState] = GenLens[SimpleState](_.game)
+  def playerLens: Lens[SimpleGameState, SimplePlayer] = GenLens[SimpleGameState](_.player)
   def locationLens: Lens[SimplePlayer, Room] = GenLens[SimplePlayer](_.location)
-  def messagesLens: Lens[SimpleState, Seq[Message]] =
-    GenLens[SimpleState](_.messages)
+  def messagesLens: Lens[SimpleState, Seq[Message]] = GenLens[SimpleState](_.messages)
 
   case class Describe(room: Room) extends Message
   case object WentNorth extends Message
   case object WentSouth extends Message
 
   def game: Game[SimpleState] = new Game[SimpleState] {
-    override def send(
-        input: String
-    )(state: SimpleState): Either[String, SimpleState] =
+    override def send(input: String)(state: SimpleState): Either[String, SimpleState] =
       for {
         dir <- input match {
           case "go n" => Right(NORTH)
@@ -102,9 +79,5 @@ object App2 extends zio.App {
   import Model._
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-    CLI[SimpleState](
-      state,
-      game,
-      pusher
-    ).start.exitCode
+    CLI[SimpleState](state, game, pusher).start.exitCode
 }


### PR DESCRIPTION
This is the alternative solution to #14, as discussed in #13's comments. Fixes the problems that made Spotless crash, and not use the correct configuration, setting correctly path and version of the configuration.

With regards to the new code conventions, these are the main differences from scalafmt default:

- **max column** is now set to 120 (IntelliJ default for Scala)
- overall configuration **favors "horizontal" code**, allowing to do when possible inline operations. When not possible for excessive line size, it formats the code accordingly (but only in that case, not always, as before)
- formatter tends to **not force blank newlines** (for example, before or after function definitions). This can be discussed, but experimentally, leaving freedom to the programmer for this point leads to more readable code.