### PR TITLE
Add state as Item parameter

### DIFF
--- a/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
@@ -25,6 +25,6 @@ trait Model {
 
   trait Item { item: I =>
     def name: String
-    def use(action: Action): Option[Update]
+    def use(action: Action, state: S): Option[Update]
   }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
@@ -9,7 +9,7 @@ object SimpleModel extends Model {
   override type I = SimpleItem
 
   case class SimpleItem(name: String) extends Item {
-    override def use(action: Action): Option[Update] = Some(x => x)
+    override def use(action: Action, state: S): Option[Update] = ??? //properties.reduce()
   }
 
   case class SimplePlayer(bag: Set[SimpleItem], location: Room) extends Player

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
@@ -2,6 +2,7 @@ package io.github.scalaquest.core.pipeline.interpreter
 
 import io.github.scalaquest.core.model.Model
 import io.github.scalaquest.core.pipeline.resolver.ResolverResult
+import io.github.scalaquest.core.pipeline.resolver.Statement.{Intransitive, Transitive, Ditransitive}
 
 trait InterpreterResult {
   def effect: Model#Update
@@ -11,6 +12,18 @@ trait Interpreter[S <: Model#State] {
   def interpret(resolverResult: ResolverResult): Either[String, InterpreterResult]
 }
 
+case class SimpleInterpreter[S <: Model#State](state: S) extends Interpreter[S] {
+
+  override def interpret(resolverResult: ResolverResult): Either[String, InterpreterResult] = {
+
+    resolverResult.statement match {
+      case Intransitive(action)                   => ???
+      case Transitive(action, target)             => ???
+      case Ditransitive(action, target1, target2) => ???
+    }
+  }
+}
+
 object Interpreter {
-  def apply[S <: Model#State](state: S): Interpreter[S] = ???
+  def apply[S <: Model#State](state: S): Interpreter[S] = SimpleInterpreter(state)
 }


### PR DESCRIPTION
This is a small modification to the base traits structure, that brings access to the state from the Interpreter and the Item, as discussed with @lippo97 @ThomasAngeliniUnibo and @corinz97.