### PR TITLE
Rename Update into Reaction

### DIFF
--- a/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
@@ -6,8 +6,8 @@ trait Model {
   type S <: State
   type I <: Item
 
-  type Self   = this.type
-  type Update = Self#S => Self#S
+  type Self     = this.type
+  type Reaction = Self#S => Self#S
 
   trait State { self: S =>
     def game: GameState
@@ -26,12 +26,12 @@ trait Model {
 
   trait Item { item: I =>
     def name: String
-    def useTransitive[SS <: Model#S, UU <: Model#Update](action: Action, state: SS): Option[UU]
+    def useTransitive[SS <: Model#S, RR <: Model#Reaction](action: Action, state: SS): Option[RR]
 
-    def useDitransitive[SS <: Model#S, II <: Model#I, UU <: Model#Update](
+    def useDitransitive[SS <: Model#S, II <: Model#I, RR <: Model#Reaction](
       action: Action,
       sideItem: II,
       state: SS
-    ): Option[UU]
+    ): Option[RR]
   }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/impl/SimpleModel.scala
@@ -7,13 +7,13 @@ object SimpleModel extends Model {
   override type I = SimpleItem
 
   trait SimpleItem extends Item {
-    override def useTransitive[SS <: Model#S, UU <: Model#Update](action: Action, state: SS): Option[UU] = None
+    override def useTransitive[SS <: Model#S, RR <: Model#Reaction](action: Action, state: SS): Option[RR] = None
 
-    override def useDitransitive[SS <: Model#S, II <: Model#I, UU <: Model#Update](
+    override def useDitransitive[SS <: Model#S, II <: Model#I, RR <: Model#Reaction](
       action: Action,
       sideItem: II,
       state: SS
-    ): Option[UU] = None
+    ): Option[RR] = None
   }
 
   case class SimplePlayer(bag: Set[SimpleItem], location: Room) extends Player

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
@@ -9,31 +9,31 @@ trait Interpreter[M <: Model] {
 }
 
 trait InterpreterResult[M <: Model] {
-  def update: M#Update
+  def reaction: M#Reaction
 }
 
 abstract class TypedInterpreter[M <: Model](val model: M) {
-  type Update = model.Update
-  type S      = model.S
-  type I      = model.I
+  type Reaction = model.Reaction
+  type S        = model.S
+  type I        = model.I
 
-  case class SimpleInterpreterResult(update: Update) extends InterpreterResult[M]
+  case class SimpleInterpreterResult(reaction: Reaction) extends InterpreterResult[M]
 
   object InterpreterResult {
-    def apply(update: Update): InterpreterResult[M] = SimpleInterpreterResult(update)
+    def apply(reaction: Reaction): InterpreterResult[M] = SimpleInterpreterResult(reaction)
   }
 
   case class SimpleInterpreter(state: S) extends Interpreter[M] {
-    private val useIntransitive: Option[Update] = ???
+    private val useIntransitive: Option[Reaction] = ???
 
     override def interpret(resolverResult: ResolverResult): Either[String, InterpreterResult[M]] = {
-      val eventualUpdate: Either[String, Update] = resolverResult.statement match {
+      val eventualReaction: Either[String, Reaction] = resolverResult.statement match {
         case Intransitive(action) =>
           useIntransitive toRight
             s"Could not recognize ${action.name}"
 
         case Transitive(action, item) =>
-          val aa: Option[Update] = item.useTransitive[S, Update](action, state: S)
+          val aa: Option[Reaction] = item.useTransitive[S, Reaction](action, state: S)
           aa.toRight(s"Could not recognize ${action.name} on ${item.name}")
 
         case Ditransitive(action, mainItem, sideItem) =>
@@ -41,7 +41,7 @@ abstract class TypedInterpreter[M <: Model](val model: M) {
             s"Could not recognize ${action.name} on ${mainItem.name} with ${sideItem.name}"
       }
 
-      eventualUpdate.map(InterpreterResult(_))
+      eventualReaction.map(InterpreterResult(_))
     }
   }
 }


### PR DESCRIPTION
To conclude the common refactoring, I renamed all instances of the term `Update` into `Reaction`, as discussed.