### PR TITLE
Upgrade scala-library from 2.13.3 to 2.13.4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -152,8 +152,7 @@ version.org.danilopianini..publish-on-central=0.3.0
 ##                                # available=0.4.1-dev07-4ada7d1
 ##                                # available=0.4.1
 
-version.org.scala-lang..scala-library=2.13.3
-##                        # available=2.13.4
+version.org.scala-lang..scala-library=2.13.4
 
 version.org.scalatest..scalatest_2.13=3.2.3
 ##                        # available=3.2.4-M1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.