### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -102,7 +102,7 @@ version.dev.zio..zio_2.13=1.0.3
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 
-version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
+version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 ##                                               # available=0.2.3-dev01-6f23ea8
 ##                                               # available=0.2.3-dev01-5b21a10
 ##                                               # available=0.2.3-dev02-668abeb
@@ -110,7 +110,6 @@ version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
 ##                                               # available=0.2.3-dev02-5fe3322
 ##                                               # available=0.2.3-dev03-54802b0
 ##                                               # available=0.2.3-dev03-3a2bc63
-##                                               # available=0.2.3
 
 version.org.danilopianini..publish-on-central=0.3.0
 ##                                # available=0.4.0-dev0c-41d440e


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.