### PR TITLE
Upgrade flexmark-all from 0.35.10 to 0.62.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ version.com.github.julien-truffaut..monocle-macro_2.13=2.0.3
 
 version.com.github.maiflai..gradle-scalatest=0.30
 
-version.com.vladsch.flexmark..flexmark-all=0.35.10
+version.com.vladsch.flexmark..flexmark-all=0.62.2
 ##                             # available=0.36.8
 ##                             # available=0.40.0
 ##                             # available=0.40.2
@@ -95,7 +95,6 @@ version.com.vladsch.flexmark..flexmark-all=0.35.10
 ##                             # available=0.61.32
 ##                             # available=0.61.34
 ##                             # available=0.62.0
-##                             # available=0.62.2
 
 version.dev.zio..zio_2.13=1.0.3
 ##            # available=1.0.4


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.