### PR TITLE
Generate Scaladoc on new releases

### DIFF
--- a/.github/workflows/auto-update-docs.yml
+++ b/.github/workflows/auto-update-docs.yml
@@ -1,0 +1,51 @@
+name: Update Docs
+
+# This workflow generates the Scaladoc on each push on main, and commits
+# the updates into the gh-pages branch.defaults:
+
+on:
+  push:
+    branches:
+      - feature/docs-auto-update
+
+jobs:
+  docs:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Correctly fetches tags. Useful to indicate the
+          # right current version into the scaladoc.
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Generate Core and CLI Scaladoc
+        run: |
+          ./gradlew :core:scaladoc
+          ./gradlew :cli:scaladoc
+
+      - name: Push Scaladoc to gh-pages
+        uses: EndBug/add-and-commit@v7.0.0
+        with:
+          # Force is required, as build directories are ignored on main;
+          # Only core and cli docs are considered, as examples scaladoc should not
+          # be considered relevant.
+          add: './core/build/docs/scaladoc ./cli/build/docs/scaladoc --force'
+          author_name: Docubot [Bot]
+          branch: gh-pages
+          message: 'Update Scaladoc'

--- a/.github/workflows/auto-update-docs.yml
+++ b/.github/workflows/auto-update-docs.yml
@@ -6,7 +6,7 @@ name: Update Docs
 on:
   push:
     branches:
-      - feature/docs-auto-update
+      - main
 
 jobs:
   docs:
@@ -34,18 +34,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Generate Core and CLI Scaladoc
+      - name: Generate Scaladoc
         run: |
           ./gradlew :core:scaladoc
           ./gradlew :cli:scaladoc
 
-      - name: Push Scaladoc to gh-pages
-        uses: EndBug/add-and-commit@v7.0.0
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
         with:
-          # Force is required, as build directories are ignored on main;
-          # Only core and cli docs are considered, as examples scaladoc should not
-          # be considered relevant.
-          add: './core/build/docs/scaladoc ./cli/build/docs/scaladoc --force'
-          author_name: Docubot [Bot]
-          branch: gh-pages
-          message: 'Update Scaladoc'
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Push Scaladoc to gh-pages
+        run: |
+          mkdir ./gh-pages/scaladoc
+          mkdir ./gh-pages/scaladoc/core
+          mkdir ./gh-pages/scaladoc/cli
+          mv ./core/build/docs/scaladoc ./gh-pages/scaladoc/core
+          mv ./cli/build/docs/scaladoc ./gh-pages/scaladoc/cli
+          cd ./gh-pages
+          git config user.name Docubot
+          git config user.email github-actions@github.com
+          git add ./scaladoc
+          git commit -m "Update Scaladoc"
+          git push


### PR DESCRIPTION
Finally, I made it!

This workflow automatically generates the Scaladoc for `core` and `cli` for each push on `main`, and saves it into the `gh-pages` branch.