### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -98,7 +98,7 @@ version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 
-version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
+version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 ##                                               # available=0.2.3-dev01-6f23ea8
 ##                                               # available=0.2.3-dev01-5b21a10
 ##                                               # available=0.2.3-dev02-668abeb
@@ -112,7 +112,6 @@ version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
 ##                                               # available=0.2.3-dev05-4fe4749
 ##                                               # available=0.2.3-dev06-1d3780f
 ##                                               # available=0.2.3-dev06-6b47ae5
-##                                               # available=0.2.3
 
 version.org.danilopianini..publish-on-central=0.4.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.