### PR TITLE
Allow resolver to better manage ambiguous descriptions

### DIFF
--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/AbstractSyntaxTreeResolver.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/AbstractSyntaxTreeResolver.scala
@@ -1,0 +1,39 @@
+package io.github.scalaquest.core.pipeline.resolver
+
+import io.github.scalaquest.core.dictionary.verbs.VerbPrep
+import io.github.scalaquest.core.model.{Action, ItemDescription, ItemRef}
+import io.github.scalaquest.core.pipeline.parser.{AbstractSyntaxTree, ParserResult}
+
+abstract class AbstractSyntaxTreeResolver extends Resolver {
+
+  def actions(v: VerbPrep): Either[String, Action]
+
+  def items(d: ItemDescription): Either[String, ItemRef]
+
+  override def resolve(parserResult: ParserResult): Either[String, ResolverResult] = {
+    for {
+      statement <- parserResult.tree match {
+        case AbstractSyntaxTree.Intransitive(verb, prep, _) =>
+          for {
+            action <- actions((verb, prep))
+          } yield Statement.Intransitive(action)
+
+        case AbstractSyntaxTree.Transitive(verb, prep, _, obj) =>
+          for {
+            action  <- actions((verb, prep))
+            itemRef <- items(obj)
+          } yield Statement.Transitive(action, itemRef)
+
+        case AbstractSyntaxTree.Ditransitive(verb, prep, _, directObj, indirectObj) =>
+          for {
+            action          <- actions((verb, prep))
+            directItemRef   <- items(directObj)
+            indirectItemRef <- items(indirectObj)
+          } yield Statement.Ditransitive(action, directItemRef, indirectItemRef)
+
+        case _ => Left("The statement is wrong.")
+      }
+    } yield ResolverResult(statement)
+  }
+
+}

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/resolver/Resolver.scala
@@ -1,8 +1,7 @@
 package io.github.scalaquest.core.pipeline.resolver
 
-import io.github.scalaquest.core.dictionary.verbs.VerbPrep
 import io.github.scalaquest.core.model.{Action, ItemDescription, ItemRef, Model}
-import io.github.scalaquest.core.pipeline.parser.{AbstractSyntaxTree, ParserResult}
+import io.github.scalaquest.core.pipeline.parser.ParserResult
 
 /**
  * A pipeline component that takes a [[AbstractSyntaxTree]] (wrapped into an [[ParserResult]] ) and
@@ -31,57 +30,18 @@ object Resolver {
 
   type Builder[S] = S => Resolver
 
-  abstract class SimpleResolver extends Resolver {
-
-    def actions: PartialFunction[VerbPrep, Action]
-
-    def items: PartialFunction[ItemDescription, Either[String, ItemRef]]
-
-    def retrieveAction(verbPrep: VerbPrep): Either[String, Action] =
-      actions lift verbPrep toRight s"Couldn't understand ${verbPrep._1}."
-
-    def retrieveItem(desc: ItemDescription): Either[String, ItemRef] =
-      (items lift desc toRight s"Couldn't understand ${desc.mkString}").flatten
-
-    override def resolve(parserResult: ParserResult): Either[String, ResolverResult] = {
-      for {
-        statement <- parserResult.tree match {
-          case AbstractSyntaxTree.Intransitive(verb, prep, _) =>
-            for {
-              action <- retrieveAction((verb, prep))
-            } yield Statement.Intransitive(action)
-
-          case AbstractSyntaxTree.Transitive(verb, prep, _, obj) =>
-            for {
-              action  <- retrieveAction((verb, prep))
-              itemRef <- retrieveItem(obj)
-            } yield Statement.Transitive(action, itemRef)
-
-          case AbstractSyntaxTree.Ditransitive(verb, prep, _, directObj, indirectObj) =>
-            for {
-              action          <- retrieveAction((verb, prep))
-              directItemRef   <- retrieveItem(directObj)
-              indirectItemRef <- retrieveItem(indirectObj)
-            } yield Statement.Ditransitive(action, directItemRef, indirectItemRef)
-
-          case _ => Left("The statement is wrong.")
-        }
-      } yield ResolverResult(statement)
-    }
-
-  }
-
   def builder[M <: Model](implicit model: M): Builder[model.S] =
     s =>
-      new SimpleResolver {
+      new AbstractSyntaxTreeResolver {
 
-        override def actions: PartialFunction[VerbPrep, Action] = s.actions
+        override def actions(v: (String, Option[String])): Either[String, Action] =
+          s.actions get v toRight s"I couldn't understand what you said."
 
-        override def items: PartialFunction[ItemDescription, Either[String, ItemRef]] =
-          d =>
-            s.scope.filter(i => d.isSubset(i.description)).toList match {
-              case x :: Nil => Right(x.ref)
-              case x :: _   => Left(s"Which ${d.mkString}?")
-            }
+        override def items(d: ItemDescription): Either[String, ItemRef] =
+          s.scope.filter(i => d.isSubset(i.description)).toList match {
+            case x :: Nil => Right(x.ref)
+            case _ :: _   => Left(s"Which ${d.mkString} are you talking about?")
+            case _        => Left(s"I can't see any ${d.mkString}.")
+          }
       }
 }


### PR DESCRIPTION
This addresses one of the issues mentioned in #78. 

This should not the THE way we have to go, it's just a way that makes it work. I think we should refactor the resolver package anyway so we can seize the opportunity and do it all at once.