### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -30,7 +30,7 @@ version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 
-version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
+version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 ##                                               # available=0.2.3-dev01-6f23ea8
 ##                                               # available=0.2.3-dev01-5b21a10
 ##                                               # available=0.2.3-dev02-668abeb
@@ -46,7 +46,6 @@ version.org.danilopianini..git-sensitive-semantic-versioning=0.2.2
 ##                                               # available=0.2.3-dev06-6b47ae5
 ##                                               # available=0.2.3-dev07-c4a8f67
 ##                                               # available=0.2.3-dev07-11ef977
-##                                               # available=0.2.3
 
 version.org.danilopianini..publish-on-central=0.4.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.