### PR TITLE
Make scala compiler stricter and solve some warnings

### DIFF
--- a/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
@@ -29,10 +29,10 @@ tasks.withType<ScalaCompile> {
             "-language:implicitConversions",
             "-language:higherKinds",
             "-Xfatal-warnings",
-            // "-Wunused:implicits",
-            // "-Wunused:imports",
+            "-Wunused:implicits",
+            "-Wunused:imports",
             "-Wunused:locals",
-            // "-Wunused:params",
+            "-Wunused:params",
             "-Wunused:privates"
     )
 }

--- a/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
@@ -24,7 +24,17 @@ repositories {
 }
 
 tasks.withType<ScalaCompile> {
-    scalaCompileOptions.additionalParameters = listOf("-feature", "-language:implicitConversions")
+    scalaCompileOptions.additionalParameters = listOf(
+            "-feature",
+            "-language:implicitConversions",
+            "-language:higherKinds",
+            "-Xfatal-warnings",
+            // "-Wunused:implicits",
+            // "-Wunused:imports",
+            "-Wunused:locals",
+            // "-Wunused:params",
+            "-Wunused:privates"
+    )
 }
 
 tasks.named<Test>("test") {

--- a/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
+++ b/cli/src/main/scala/io/github/scalaquest/cli/CLI.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.cli
 
-import io.github.scalaquest.core.model.{MessagePusher, Model}
 import io.github.scalaquest.core.Game
+import io.github.scalaquest.core.model.{MessagePusher, Model}
 import zio.console._
 import zio.{ExitCode, UIO, URIO, ZIO}
 

--- a/cli/src/test/scala/io/github/scalaquest/cli/CLITest.scala
+++ b/cli/src/test/scala/io/github/scalaquest/cli/CLITest.scala
@@ -1,14 +1,14 @@
 package io.github.scalaquest.cli
 
 import io.github.scalaquest.cli.CLI.readLine
+import io.github.scalaquest.cli.CLITestHelper._
 import io.github.scalaquest.core.model.RoomRef
-import zio.test._
-import zio.test.Assertion._
-import zio.test.environment._
-import zio.test.junit.JUnitRunnableSpec
-import CLITestHelper._
 import zio.ZIO
 import zio.console.Console
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment._
+import zio.test.junit.JUnitRunnableSpec
 
 import scala.annotation.nowarn
 

--- a/cli/src/test/scala/io/github/scalaquest/cli/CLITest.scala
+++ b/cli/src/test/scala/io/github/scalaquest/cli/CLITest.scala
@@ -10,6 +10,10 @@ import CLITestHelper._
 import zio.ZIO
 import zio.console.Console
 
+import scala.annotation.nowarn
+
+// Suppress weird warning
+@nowarn("msg=pure expression")
 class CLITest extends JUnitRunnableSpec {
 
   case class TestCLI(start: ZIO[Console, Exception, Unit]) extends CLI

--- a/cli/src/test/scala/io/github/scalaquest/cli/CLITestHelper.scala
+++ b/cli/src/test/scala/io/github/scalaquest/cli/CLITestHelper.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.cli
 
-import io.github.scalaquest.core.model.{Message, RoomRef}
 import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel
+import io.github.scalaquest.core.model.{Message, RoomRef}
 
 object CLITestHelper {
 

--- a/core/src/main/scala/io/github/scalaquest/core/application/ApplicationStructure.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/application/ApplicationStructure.scala
@@ -1,14 +1,12 @@
 package io.github.scalaquest.core.application
 
 import cats.Functor
-import io.github.scalaquest.core.dictionary.Dictionary
 import io.github.scalaquest.core.dictionary.generators.GeneratorK
 import io.github.scalaquest.core.dictionary.verbs.{Verb, VerbPrep}
 import io.github.scalaquest.core.model.{Action, ItemRef, Model}
 import io.github.scalaquest.core.parsing.engine.{DCGLibrary, Engine, Theory}
 import io.github.scalaquest.core.pipeline.Pipeline
 import io.github.scalaquest.core.pipeline.interpreter.Interpreter
-import io.github.scalaquest.core.pipeline.interpreter.Interpreter.Builder
 import io.github.scalaquest.core.pipeline.lexer.SimpleLexer
 import io.github.scalaquest.core.pipeline.parser.Parser
 import io.github.scalaquest.core.pipeline.reducer.Reducer

--- a/core/src/main/scala/io/github/scalaquest/core/application/Environment.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/application/Environment.scala
@@ -1,7 +1,6 @@
 package io.github.scalaquest.core.application
 
-import io.github.scalaquest.core.model.RoomRef
-import io.github.scalaquest.core.model.Model
+import io.github.scalaquest.core.model.{Model, RoomRef}
 
 abstract class Environment[RM <: Model#Room] {
   def allTheRooms: Set[RM]

--- a/core/src/main/scala/io/github/scalaquest/core/application/ProgramFromDictionary.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/application/ProgramFromDictionary.scala
@@ -1,12 +1,12 @@
 package io.github.scalaquest.core.application
 
-import cats.{Functor, Monoid}
-import io.github.scalaquest.core.dictionary.generators.{Generator, GeneratorK, combineAll}
-import io.github.scalaquest.core.dictionary.verbs.Verb
-import io.github.scalaquest.core.dictionary.{Dictionary, Item}
-import io.github.scalaquest.core.parsing.scalog.{Clause, Program}
-import io.github.scalaquest.core.dictionary.implicits.{verbToProgram, itemToProgram, programMonoid}
+import cats.Functor
+import io.github.scalaquest.core.dictionary.Item
 import io.github.scalaquest.core.dictionary.generators.implicits.listGenerator
+import io.github.scalaquest.core.dictionary.generators.{GeneratorK, combineAll}
+import io.github.scalaquest.core.dictionary.implicits.{itemToProgram, programMonoid, verbToProgram}
+import io.github.scalaquest.core.dictionary.verbs.Verb
+import io.github.scalaquest.core.parsing.scalog.Program
 
 case class ProgramFromDictionary[I <: Item](verbs: Set[Verb], items: Set[I]) {
 

--- a/core/src/main/scala/io/github/scalaquest/core/dictionary/DictionaryImplicits.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/dictionary/DictionaryImplicits.scala
@@ -1,9 +1,9 @@
 package io.github.scalaquest.core.dictionary
 
 import cats.Monoid
-import io.github.scalaquest.core.dictionary.generators.{Generator, GeneratorK}
+import io.github.scalaquest.core.dictionary.generators.Generator
 import io.github.scalaquest.core.dictionary.verbs.{Verb, VerbPrep}
-import io.github.scalaquest.core.model.{Action, ItemRef, Model}
+import io.github.scalaquest.core.model.{Action, ItemRef}
 import io.github.scalaquest.core.parsing.scalog.{Clause, Program}
 
 /**

--- a/core/src/main/scala/io/github/scalaquest/core/dictionary/verbs/ClauseOps.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/dictionary/verbs/ClauseOps.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.core.dictionary.verbs
 
 import io.github.scalaquest.core.parsing.scalog.Fact
-import io.github.scalaquest.core.parsing.scalog.dsl.{termToFact, intToNumber, stringToAtom}
+import io.github.scalaquest.core.parsing.scalog.dsl.{intToNumber, stringToAtom, termToFact}
 
 trait ClauseOps { self: BaseVerb =>
 

--- a/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/Model.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.core.model
 
 import io.github.scalaquest.core.dictionary.verbs.VerbPrep
-import monocle.{Lens, PLens}
+import monocle.Lens
 
 /**
  * A way to represent the basic linked concepts of the story, in an extendible way. Usage example:

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/CommonsExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/CommonsExt.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.core.model.behaviorBased.commons
 
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
-import io.github.scalaquest.core.model.behaviorBased.commons.grounds.CommonGroundExt
 import io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors.CommonGroundBehaviorsExt
+import io.github.scalaquest.core.model.behaviorBased.commons.grounds.CommonGroundExt
 import io.github.scalaquest.core.model.behaviorBased.commons.itemBehaviors.CommonItemBehaviorsExt
 import io.github.scalaquest.core.model.behaviorBased.commons.items.CommonItemsExt
 import io.github.scalaquest.core.model.behaviorBased.commons.reactions.CommonReactionsExt

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbs.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbs.scala
@@ -1,21 +1,8 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.actioning
 
-import io.github.scalaquest.core.dictionary.verbs.{
-  BaseVerb,
-  Ditransitive,
-  Intransitive,
-  Transitive,
-  Verb
-}
+import io.github.scalaquest.core.dictionary.verbs.{Ditransitive, Intransitive, Transitive, Verb}
 import io.github.scalaquest.core.model.Direction
-import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonActions.{
-  Eat,
-  Enter,
-  Go,
-  Inspect,
-  Open,
-  Take
-}
+import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonActions._
 
 object CommonVerbs {
 

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/CommonGroundBehaviorsExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/CommonGroundBehaviorsExt.scala
@@ -1,6 +1,5 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors
 
-import io.github.scalaquest.core.model.Model
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
 import io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors.impl.{
   InspectableExt,
@@ -8,8 +7,8 @@ import io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors.imp
 }
 
 /**
- * When mixed into a [[Model]], it enables the implementation for the common behaviors provided by
+ * When mixed into a Model, it enables the implementation for the common behaviors provided by
  * ScalaQuest Core. It requires the storyteller to implement all the required [[monocle.Lens]], used
- * by the implementation to access and re-generate the concrete [[Model.State]].
+ * by the implementation to access and re-generate the concrete State.
  */
 trait CommonGroundBehaviorsExt extends BehaviorBasedModel with NavigableExt with InspectableExt

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/CommonItemBehaviorsExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/CommonItemBehaviorsExt.scala
@@ -1,6 +1,5 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.itemBehaviors
 
-import io.github.scalaquest.core.model.Model
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
 import io.github.scalaquest.core.model.behaviorBased.commons.itemBehaviors.impl.{
   EatableExt,
@@ -10,9 +9,9 @@ import io.github.scalaquest.core.model.behaviorBased.commons.itemBehaviors.impl.
 }
 
 /**
- * When mixed into a [[Model]], it enables the implementation for the common behaviors provided by
+ * When mixed into a Model, it enables the implementation for the common behaviors provided by
  * ScalaQuest Core. It requires the storyteller to implement all the required [[monocle.Lens]], used
- * by the implementation to access and re-generate the concrete [[Model.State]].
+ * by the implementation to access and re-generate the concrete State.
  */
 trait CommonItemBehaviorsExt
   extends BehaviorBasedModel

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/impl/RoomLinkExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/impl/RoomLinkExt.scala
@@ -47,8 +47,7 @@ trait RoomLinkExt
     endRoomDirection: Direction,
     openable: Option[Openable] = None,
     onEnterExtra: Option[Reaction] = None
-  )(implicit subject: I)
-    extends RoomLink
+  ) extends RoomLink
     with Delegate {
 
     /**
@@ -106,7 +105,6 @@ trait RoomLinkExt
       openableBuilder: Option[I => Openable] = None,
       onEnterExtra: Option[Reaction] = None
     ): I => RoomLink =
-      item =>
-        SimpleRoomLink(endRoom, endRoomDirection, openableBuilder.map(_(item)), onEnterExtra)(item)
+      item => SimpleRoomLink(endRoom, endRoomDirection, openableBuilder.map(_(item)), onEnterExtra)
   }
 }

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/CommonItemsExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/CommonItemsExt.scala
@@ -1,6 +1,5 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.items
 
-import io.github.scalaquest.core.model.Model
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
 import io.github.scalaquest.core.model.behaviorBased.commons.items.impl.{
   DoorExt,
@@ -10,7 +9,7 @@ import io.github.scalaquest.core.model.behaviorBased.commons.items.impl.{
 }
 
 /**
- * When mixed into a [[Model]], it enables the implementation for the common items provided by
+ * When mixed into a Model, it enables the implementation for the common items provided by
  * ScalaQuest Core.
  */
 trait CommonItemsExt

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/impl/FoodExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/impl/FoodExt.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.items.impl
 
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
-import io.github.scalaquest.core.model.{ItemDescription, ItemRef}
 import io.github.scalaquest.core.model.behaviorBased.commons.itemBehaviors.impl.EatableExt
+import io.github.scalaquest.core.model.{ItemDescription, ItemRef}
 
 /**
  * The trait makes possible to mix into a [[BehaviorBasedModel]] the Food Item.

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/pushing/CommonStringPusher.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/pushing/CommonStringPusher.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.pushing
 
-import io.github.scalaquest.core.model.{ComposableStringPusher, Direction}
 import io.github.scalaquest.core.model.TriggerPusher.{MessageTriggers, StringMessageTriggers}
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
+import io.github.scalaquest.core.model.{ComposableStringPusher, Direction}
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/reactions/CommonReactionsExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/commons/reactions/CommonReactionsExt.scala
@@ -1,16 +1,7 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.reactions
 
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
-import io.github.scalaquest.core.model.behaviorBased.commons.reactions.impl.{
-  EatExt,
-  EmptyExt,
-  EnterExt,
-  FinishGameExt,
-  InspectLocationExt,
-  NavigateExt,
-  OpenExt,
-  TakeExt
-}
+import io.github.scalaquest.core.model.behaviorBased.commons.reactions.impl._
 
 trait CommonReactionsExt
   extends BehaviorBasedModel

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/impl/DoorKeyBuilderExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/impl/DoorKeyBuilderExt.scala
@@ -2,7 +2,7 @@ package io.github.scalaquest.core.model.behaviorBased.simple.builders.impl
 
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
 import io.github.scalaquest.core.model.behaviorBased.commons.CommonsExt
-import io.github.scalaquest.core.model.{Direction, ItemDescription, ItemRef}
+import io.github.scalaquest.core.model.{Direction, ItemDescription}
 
 trait DoorKeyBuilderExt extends BehaviorBasedModel with CommonsExt {
 

--- a/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/impl/OpKeyBuilderExt.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/impl/OpKeyBuilderExt.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.core.model.behaviorBased.simple.builders.impl
 
+import io.github.scalaquest.core.model.ItemDescription
 import io.github.scalaquest.core.model.behaviorBased.BehaviorBasedModel
 import io.github.scalaquest.core.model.behaviorBased.commons.CommonsExt
-import io.github.scalaquest.core.model.{ItemDescription, ItemRef}
 
 trait OpKeyBuilderExt extends BehaviorBasedModel with CommonsExt {
 

--- a/core/src/main/scala/io/github/scalaquest/core/parsing/engine/Library.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/parsing/engine/Library.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.core.parsing.engine
 
-import alice.tuprolog.{Library => TuPrologLibrary}
 import alice.tuprolog.lib.{DCGLibrary => TuPrologDCGLibrary}
+import alice.tuprolog.{Library => TuPrologLibrary}
 
 /** Representation of a Prolog library */
 abstract class BaseLibrary

--- a/core/src/main/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngine.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngine.scala
@@ -14,6 +14,9 @@ import io.github.scalaquest.core.parsing.engine.exceptions.InvalidTheoryExceptio
 import io.github.scalaquest.core.parsing.engine.tuprolog.TuPrologEngine.{buildCompound, buildNumber}
 import io.github.scalaquest.core.parsing.scalog
 import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Number, Term, Variable}
+import io.github.scalaquest.core.dictionary.generators.Generator
+
+import scala.annotation.nowarn
 
 /**
  * Engine implementation that uses a tuProlog engine under the hood.
@@ -56,6 +59,7 @@ object TuPrologEngine {
       .map(_.toTerm)
   }
 
+  @nowarn("msg=exhaustive")
   /**
    * @note
    *   this will fail if called with a Struct with no arguments.

--- a/core/src/main/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngine.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngine.scala
@@ -9,12 +9,11 @@ import alice.tuprolog.{
   Term => TuPrologTerm,
   Theory => TuPrologTheory
 }
-import io.github.scalaquest.core.parsing.engine.{Engine, Library, Solution, Theory}
 import io.github.scalaquest.core.parsing.engine.exceptions.InvalidTheoryException
 import io.github.scalaquest.core.parsing.engine.tuprolog.TuPrologEngine.{buildCompound, buildNumber}
+import io.github.scalaquest.core.parsing.engine.{Engine, Library, Solution, Theory}
 import io.github.scalaquest.core.parsing.scalog
-import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Number, Term, Variable}
-import io.github.scalaquest.core.dictionary.generators.Generator
+import io.github.scalaquest.core.parsing.scalog._
 
 import scala.annotation.nowarn
 

--- a/core/src/main/scala/io/github/scalaquest/core/parsing/scalog/dsl/CompoundBuilder.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/parsing/scalog/dsl/CompoundBuilder.scala
@@ -1,6 +1,6 @@
 package io.github.scalaquest.core.parsing.scalog.dsl
 
-import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Term}
+import io.github.scalaquest.core.parsing.scalog.Atom
 
 abstract class CompoundBase {
   def functor: Atom

--- a/core/src/main/scala/io/github/scalaquest/core/parsing/scalog/dsl/Extractors.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/parsing/scalog/dsl/Extractors.scala
@@ -2,6 +2,8 @@ package io.github.scalaquest.core.parsing.scalog.dsl
 
 import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Term}
 
+import scala.annotation.nowarn
+
 trait Extractors extends CompoundBase {
 
   object extractor {
@@ -17,6 +19,7 @@ trait Extractors extends CompoundBase {
 
     object toStrings extends CompoundExtractor[String] {
 
+      @nowarn("msg=unchecked.*erasure")
       override def unapplySeq(term: Term): Option[Seq[String]] =
         term match {
           case Compound(f, Atom(t0), terms: List[Atom]) if f == functor =>

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/interpreter/Interpreter.scala
@@ -1,6 +1,6 @@
 package io.github.scalaquest.core.pipeline.interpreter
 
-import io.github.scalaquest.core.model.{ItemRef, Model}
+import io.github.scalaquest.core.model.Model
 import io.github.scalaquest.core.pipeline.resolver.{ResolverResult, Statement}
 
 /**

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/PrologParser.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/PrologParser.scala
@@ -2,8 +2,7 @@ package io.github.scalaquest.core.pipeline.parser
 
 import io.github.scalaquest.core.model.{BaseItem, DecoratedItem, ItemDescription}
 import io.github.scalaquest.core.parsing.engine.Engine
-import io.github.scalaquest.core.parsing.scalog
-import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, ListP, Term, Variable}
+import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Term, Variable}
 import io.github.scalaquest.core.pipeline.lexer.LexerResult
 
 import scala.annotation.nowarn

--- a/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/PrologParser.scala
+++ b/core/src/main/scala/io/github/scalaquest/core/pipeline/parser/PrologParser.scala
@@ -6,6 +6,8 @@ import io.github.scalaquest.core.parsing.scalog
 import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, ListP, Term, Variable}
 import io.github.scalaquest.core.pipeline.lexer.LexerResult
 
+import scala.annotation.nowarn
+
 case class SimpleParserResult(tree: AbstractSyntaxTree) extends ParserResult
 
 trait Helpers {
@@ -24,6 +26,8 @@ trait Helpers {
   object ItemDescription {
     import dsl.decorated
 
+    @nowarn("msg=not all missing cases are reported")
+    @nowarn("msg=match.*exhaustive")
     private def toItemDescription(term: Term): ItemDescription =
       term match {
         case Atom(name) => BaseItem(name)

--- a/core/src/test/scala/io/github/scalaquest/core/dictionary/DictionaryImplicitsTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/dictionary/DictionaryImplicitsTest.scala
@@ -4,7 +4,7 @@ import io.github.scalaquest.core.dictionary.generators.{Generator, combineAll}
 import io.github.scalaquest.core.dictionary.verbs.{Transitive, Verb, VerbPrep}
 import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel
 import io.github.scalaquest.core.model.{Action, ItemDescription, ItemRef}
-import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Fact, Number, Program}
+import io.github.scalaquest.core.parsing.scalog._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/io/github/scalaquest/core/dictionary/generators/GeneratorImplicitsTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/dictionary/generators/GeneratorImplicitsTest.scala
@@ -8,8 +8,8 @@ class GeneratorImplicitsTest extends AnyWordSpec with Matchers {
   "Using the implicits" when {
     "calling a new generatorK from a list" should {
       "return an instance" in {
-        import implicits.listGenerator
         import cats.Monoid
+        import implicits.listGenerator
         implicit val generator = Generator.instance((x: Int) => x)
         implicit val monoid    = Monoid.instance[Int](0, _ + _)
         val generatorK         = GeneratorK[List, Int, Int]

--- a/core/src/test/scala/io/github/scalaquest/core/dictionary/generators/GeneratorTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/dictionary/generators/GeneratorTest.scala
@@ -1,6 +1,6 @@
 package io.github.scalaquest.core.dictionary.generators
 
-import io.github.scalaquest.core.dictionary.generators.Generator.{instance, makeEntry}
+import io.github.scalaquest.core.dictionary.generators.Generator.makeEntry
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/io/github/scalaquest/core/model/DirectionTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/DirectionTest.scala
@@ -1,6 +1,6 @@
 package io.github.scalaquest.core.model
 
-import io.github.scalaquest.core.model.Direction.{Down, East, North, South, Up, West}
+import io.github.scalaquest.core.model.Direction._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/io/github/scalaquest/core/model/ItemDescriptionTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/ItemDescriptionTest.scala
@@ -27,28 +27,25 @@ class ItemDescriptionTest extends AnyWordSpec with Matchers {
   }
   "Item description dsl" when {
     import ItemDescription.dsl._
-    val apple       = i("apple")
-    val redApple    = i(d("red"), "apple")
-    val redBigApple = i(d("red", "big"), "apple")
-    val wrongApple  = ItemDescription("red", "big", "apple")
-    val rightApple  = ItemDescription("apple", "big", "red")
+    val apple                  = i("apple")
+    val redApple               = i(d("red"), "apple")
+    val brownSmallSlipperyRock = i(d("brown", "small", "slippery"), "rock")
     "provided only the base item" should {
       "create a base item" in {
-        i("apple") shouldBe BaseItem("apple")
+        apple shouldBe BaseItem("apple")
       }
     }
     "provided a decorator" should {
       "create a decorated item" in {
-        i(d("red"), "apple") shouldBe DecoratedItem("red", BaseItem("apple"))
+        redApple shouldBe DecoratedItem("red", BaseItem("apple"))
       }
     }
     "provided multiple decorators" should {
       "create a nested decorated item" in {
-        val matcher = DecoratedItem(
+        brownSmallSlipperyRock shouldBe DecoratedItem(
           "brown",
           DecoratedItem("small", DecoratedItem("slippery", BaseItem("rock")))
         )
-        i(d("brown", "small", "slippery"), "rock") shouldBe matcher
       }
     }
   }

--- a/core/src/test/scala/io/github/scalaquest/core/model/TriggerPusherTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/TriggerPusherTest.scala
@@ -1,9 +1,9 @@
 package io.github.scalaquest.core.model
 
+import io.github.scalaquest.core.TestsUtils
 import io.github.scalaquest.core.model.TriggerPusher.MessageTriggers
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.github.scalaquest.core.TestsUtils
 
 class TriggerPusherTest extends AnyWordSpec with Matchers {
   import TestsUtils.model.Messages._

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbsTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbsTest.scala
@@ -1,6 +1,5 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.actioning
 
-import io.github.scalaquest.core.dictionary.verbs.Verb
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbsTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/actioning/CommonVerbsTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class CommonVerbsTest extends AnyWordSpec with Matchers {
   "CommonVerbs" should {
     "Contain a set of commonly used verbs, with their name" in {
-      CommonVerbs() shouldBe a[Set[Verb]]
+      CommonVerbs() shouldBe a[Set[_]]
     }
   }
 }

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/impl/InspectableTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/impl/InspectableTest.scala
@@ -1,6 +1,5 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors.impl
 
-import io.github.scalaquest.core.TestsUtils
 import io.github.scalaquest.core.TestsUtils.model.{
   BehaviorBasedGround,
   GroundBehavior,

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/impl/InspectableTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/groundBehaviors/impl/InspectableTest.scala
@@ -1,8 +1,13 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.groundBehaviors.impl
 
 import io.github.scalaquest.core.TestsUtils
-import TestsUtils.{door, key, simpleState, startRoom, targetRoom}
-import TestsUtils.model.{BehaviorBasedGround, GroundBehavior, Inspectable, Messages}
+import io.github.scalaquest.core.TestsUtils.model.{
+  BehaviorBasedGround,
+  GroundBehavior,
+  Inspectable,
+  Messages
+}
+import io.github.scalaquest.core.TestsUtils._
 import io.github.scalaquest.core.model.Direction
 import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonActions.Inspect
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/impl/RoomLinkTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/itemBehaviors/impl/RoomLinkTest.scala
@@ -6,8 +6,8 @@ import io.github.scalaquest.core.model.{Direction, ItemDescription, ItemRef}
 import org.scalatest.wordspec.AnyWordSpec
 
 class RoomLinkTest extends AnyWordSpec {
-  import TestsUtils.model._
   import TestsUtils._
+  import TestsUtils.model._
 
   "A RoomLinkBehavior" when {
 

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/impl/KeyTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/items/impl/KeyTest.scala
@@ -5,8 +5,8 @@ import io.github.scalaquest.core.model.ItemDescription
 import org.scalatest.wordspec.AnyWordSpec
 
 class KeyTest extends AnyWordSpec {
-  import TestsUtils.model._
   import TestsUtils._
+  import TestsUtils.model._
 
   "A Key" when {
     val key       = Key(ItemDescription("key"), Seq(Takeable.builder(), Eatable.builder()))

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/pushing/CommonStringPusherTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/commons/pushing/CommonStringPusherTest.scala
@@ -1,10 +1,9 @@
 package io.github.scalaquest.core.model.behaviorBased.commons.pushing
 
-import io.github.scalaquest.core.TestsUtils.{apple, door, key, startRoom, targetRoom}
+import io.github.scalaquest.core.TestsUtils.model.Messages._
+import io.github.scalaquest.core.TestsUtils._
 import io.github.scalaquest.core.model.Direction
 import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel
-import io.github.scalaquest.core.TestsUtils.model.Messages._
-
 import org.scalatest.wordspec.AnyWordSpec
 
 class CommonStringPusherTest extends AnyWordSpec {

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/BehaviorBasedModelTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/BehaviorBasedModelTest.scala
@@ -8,12 +8,12 @@ import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonAct
   Take
 }
 import io.github.scalaquest.core.model.{Direction, ItemDescription, ItemRef}
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class BehaviorBasedModelTest extends AnyWordSpec with Matchers {
-  import TestsUtils.model._
   import TestsUtils._
+  import TestsUtils.model._
 
   "A BehaviorBasedItem" should {
     val behavior = new ItemBehavior {

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/DoorKeyBuilderExtTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/builders/DoorKeyBuilderExtTest.scala
@@ -5,8 +5,8 @@ import io.github.scalaquest.core.model.{Direction, ItemDescription}
 import org.scalatest.wordspec.AnyWordSpec
 
 class DoorKeyBuilderExtTest extends AnyWordSpec {
-  import TestsUtils.model._
   import TestsUtils._
+  import TestsUtils.model._
 
   "A DoorKeyBuilder" should {
     val (door, key) = doorKeyBuilder(

--- a/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/impl/SimpleRoomExtTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/model/behaviorBased/simple/impl/SimpleRoomExtTest.scala
@@ -5,8 +5,8 @@ import io.github.scalaquest.core.model.Direction
 import org.scalatest.wordspec.AnyWordSpec
 
 class SimpleRoomExtTest extends AnyWordSpec {
-  import TestsUtils.model._
   import TestsUtils._
+  import TestsUtils.model._
 
   "A Room" should {
     val room  = Room("room", Map(Direction.North -> targetRoom.ref), Set.empty)

--- a/core/src/test/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngineTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/parsing/engine/tuprolog/TuPrologEngineTest.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.core.parsing.engine.tuprolog
 
-import io.github.scalaquest.core.parsing.engine.exceptions.InvalidTheoryException
 import io.github.scalaquest.core.parsing.engine._
+import io.github.scalaquest.core.parsing.engine.exceptions.InvalidTheoryException
 import io.github.scalaquest.core.parsing.scalog.{Atom, Compound, Number, Variable}
 import org.scalatest.Inspectors._
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/io/github/scalaquest/core/pipeline/interpreter/InterpreterTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/pipeline/interpreter/InterpreterTest.scala
@@ -1,14 +1,6 @@
 package io.github.scalaquest.core.pipeline.interpreter
 
-import io.github.scalaquest.core.TestsUtils.{
-  apple,
-  appleItemRef,
-  door,
-  doorItemRef,
-  key,
-  keyItemRef,
-  simpleState
-}
+import io.github.scalaquest.core.TestsUtils._
 import io.github.scalaquest.core.model.Direction
 import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonActions.{
   Go,

--- a/core/src/test/scala/io/github/scalaquest/core/pipeline/reducer/ReducerTest.scala
+++ b/core/src/test/scala/io/github/scalaquest/core/pipeline/reducer/ReducerTest.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.core.pipeline.reducer
 
 import io.github.scalaquest.core.TestsUtils.{apple, simpleState}
-import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel.bagLens
 import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel
+import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel.bagLens
 import io.github.scalaquest.core.pipeline.interpreter.InterpreterResult
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/EscapeRoom.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/EscapeRoom.scala
@@ -1,8 +1,8 @@
 package io.github.scalaquest.examples.escaperoom
 
 import io.github.scalaquest.cli._
-import io.github.scalaquest.core.model.StringPusher
 import io.github.scalaquest.core.Game
+import io.github.scalaquest.core.model.StringPusher
 import io.github.scalaquest.core.pipeline.Pipeline
 
 abstract class GameCLIApp extends CLIApp {

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/Items.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/Items.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.examples.escaperoom
 
-import io.github.scalaquest.core.model.ItemDescription.dsl.{d, i}
 import io.github.scalaquest.core.model.Direction
+import io.github.scalaquest.core.model.ItemDescription.dsl.{d, i}
 import io.github.scalaquest.examples.escaperoom.Pusher.DeliciousMessage
 
 object Items {

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/Pusher.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/Pusher.scala
@@ -1,7 +1,7 @@
 package io.github.scalaquest.examples.escaperoom
 
-import io.github.scalaquest.core.model.{Message, StringPusher}
 import io.github.scalaquest.core.model.behaviorBased.commons.pushing.CommonStringPusher
+import io.github.scalaquest.core.model.{Message, StringPusher}
 
 object Pusher {
   import model.Messages._

--- a/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/package.scala
+++ b/examples/escape-room/src/main/scala/io/github/scalaquest/examples/escaperoom/package.scala
@@ -1,7 +1,6 @@
 package io.github.scalaquest.examples
 
 import io.github.scalaquest.core.application.ApplicationStructure
-import io.github.scalaquest.core.dictionary.Dictionary
 import io.github.scalaquest.core.dictionary.verbs.Verb
 import io.github.scalaquest.core.model.behaviorBased.commons.actioning.CommonVerbs
 import io.github.scalaquest.core.model.behaviorBased.simple.SimpleModel

--- a/examples/escape-room/src/test/scala/io.github.scalaquest.examples.escaperoom/ItemsTest.scala
+++ b/examples/escape-room/src/test/scala/io.github.scalaquest.examples.escaperoom/ItemsTest.scala
@@ -1,9 +1,9 @@
 package io.github.scalaquest.examples.escaperoom
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import model.Messages._
 import model._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class ItemsTest extends AnyWordSpec with Matchers {
 

--- a/examples/escape-room/src/test/scala/io.github.scalaquest.examples.escaperoom/PusherTest.scala
+++ b/examples/escape-room/src/test/scala/io.github.scalaquest.examples.escaperoom/PusherTest.scala
@@ -1,10 +1,9 @@
 package io.github.scalaquest.examples.escaperoom
 
 import io.github.scalaquest.examples.escaperoom.Pusher.DeliciousMessage
+import model.Messages._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import model._
-import model.Messages._
 
 class PusherTest extends AnyWordSpec with Matchers {
   "The default pusher object" should {


### PR DESCRIPTION
This pull request makes the scala compiler stricter, blocking compilation on every warning. Furthermore it enables the following warnings:
* unused locals
* unused private fields

Then I made some changes across the whole project in order to make it compile again, solving the warnings popping out.

I commented out some settings from what I initially set (unused imports, unused implicits and unused params) because I didn't actually know how to solve the errors that came out. I am once again asking for your help, @scalaquest/team-1.