### PR TITLE
Upgrade scala-library from 2.13.4 to 2.13.5

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -49,7 +49,7 @@ version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 
 version.org.danilopianini..publish-on-central=0.4.2
 
-version.org.scala-lang..scala-library=2.13.4
+version.org.scala-lang..scala-library=2.13.5
 
 version.org.scalatest..scalatest_2.13=3.2.5
 ##                        # available=3.2.4-M1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.