### PR TITLE
Release to Maven Central

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -46,8 +46,8 @@ jobs:
           release_name: ${{ env.RELEASE_VERSION }}
           prerelease: true
 
-      - name: Generate distributions
-        run: ./gradlew distZip
+      - name: Generate assets
+        run: ./gradlew build
 
       - name: Upload release assets
         uses: dwenegar/upload-release-assets@v1
@@ -60,3 +60,12 @@ jobs:
             ./examples/poke-quest/build/distributions
             ./cli/build/libs
             ./core/build/libs
+
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
           body: |
             This PR merges the main branch back into dev. This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates, are also present on the dev branch.
 
-      - name: Generate distributions
-        run: ./gradlew distZip
+      - name: Generate assets
+        run: ./gradlew build
 
       - name: Upload release assets
         uses: dwenegar/upload-release-assets@v1
@@ -84,6 +84,16 @@ jobs:
             ./examples/poke-quest/build/distributions
             ./cli/build/libs
             ./core/build/libs
+
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+
 
       - name: Generate Scaladoc
         run: |

--- a/README.md
+++ b/README.md
@@ -57,15 +57,36 @@ The official documentation of the project consists in:
 
 ## How to use the game creation framework?
 
-You can use `core` or `cli` libraries by downloading them from the
-[release page](https://github.com/scalaquest/PPS-19-ScalaQuest/releases/latest),
-and including them as project dependencies.
 
 Including the `cli` jar is sufficient to start programming your CLI game, as the
-module includes `core` as an internal dependency.
+module includes `core` as an internal dependency. Importing the `core` solely is recommended only
+if you want to define your personal game interface, different from the standard 
+CLI (a web interface, for example).
 
-Importing the `core` solely is recommended only if you want to define your
-personal game interface, different from the standard CLI (e.g. a web interface).
+You can use `core` or `cli` libraries by including them as dependencies for your Gradle project.
+Add this lines to the `build.gradle.kts`:
+
+```kotlin
+dependencies {
+
+  // Add the cli as dependency. This is sufficient to start 
+  // building your game. Change the version to the latest available.
+  implementation("io.scalaquest:cli:0.3.0")
+  
+  // Add the core as dependency. Change the version to the latest available.
+  implementation("io.scalaquest:core:0.3.0")
+}
+```
+
+
+You can find [here](https://mvnrepository.com/artifact/io.github.scalaquest/core) the latest version 
+for the `core`, and [here](https://mvnrepository.com/artifact/io.github.scalaquest/cli) the latest 
+version for the `cli`.
+
+Alternatively, you download the libraries from the
+[release page](https://github.com/scalaquest/PPS-19-ScalaQuest/releases/latest),
+and include them as project dependencies.
+
 
 ## How to play the example games?
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     //These implementation dependencies specifies versions for the external plugins
     // used inside the project convention plugins (i.e. common, examples, libraries)
     implementation("org.danilopianini:git-sensitive-semantic-versioning:_")
-    implementation("org.danilopianini:publish-on-central:_")
     implementation("com.github.maiflai:gradle-scalatest:_")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:_")
     implementation("gradle.plugin.org.scoverage:gradle-scoverage:_")

--- a/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.common-scala-conventions.gradle.kts
@@ -3,19 +3,19 @@
  */
 
 plugins {
-    // Adds support for Scala
+    // Adds support for Scala.
     scala
 
-    // Adds scoverage support
+    // Adds scoverage support.
     id("org.scoverage")
 
-    // Support for semantic git-sensitive semantic versioning
+    // Support for semantic git-sensitive semantic versioning.
     id("org.danilopianini.git-sensitive-semantic-versioning")
 
-    // Plugin used to enable ScalaTest inside Gradle
+    // Plugin used to enable ScalaTest inside Gradle.
     id("com.github.maiflai.scalatest")
 
-    // A scala linter-formatter
+    // A scala linter-formatter.
     id("com.diffplug.spotless")
 }
 
@@ -60,27 +60,27 @@ tasks.register("generateVersionFile") {
 }
 
 spotless {
-    // scala format with Scalafmt
+    // Scala formatting with Scalafmt.
     scala {
         scalafmt("2.7.5").configFile("${rootDir.absolutePath}/.scalafmt.conf")
     }
 }
 
 dependencies {
-    // Enables Scala 2.13 Standard Library inside every subproject
+    // Enables Scala 2.13 Standard Library inside every subproject.
     implementation("org.scala-lang:scala-library:_")
 
-    // Lenses
+    // Lenses.
     implementation("com.github.julien-truffaut:monocle-core_2.13:_")
     implementation("com.github.julien-truffaut:monocle-macro_2.13:_")
 
-    // Cats
+    // Cats.
     implementation("org.typelevel:cats-core_2.13:2.3.1")
 
-    // The ScalaTest framework
+    // The ScalaTest framework.
     testImplementation("org.scalatest:scalatest_2.13:_")
 
     // Dependency required by the Maiflai Scalatest plugin to correctly generate HTML test reports.
-    // The version is hardcoded, as maiflai.scalatest requires this specific version
+    // The version is hardcoded, as maiflai.scalatest requires this specific version.
     testRuntimeOnly("com.vladsch.flexmark:flexmark-all:0.35.10")
 }

--- a/buildSrc/src/main/kotlin/scalaquest.examples-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.examples-conventions.gradle.kts
@@ -4,14 +4,14 @@
  */
 
 plugins {
-    // Apply the common convention plugin for shared build configuration between library and application projects
+    // Apply the common convention plugin for shared build configuration between library and application projects.
     id("scalaquest.common-scala-conventions")
 
-    // Apply the application plugin to add support for building a CLI application in Java
+    // Apply the application plugin to add support for building a CLI application in Java.
     application
 }
 
-// examples do not need coverage checks
+// The coverage threshold into the examples is not mandatory.
 scoverage {
     minimumRate.set(0.toBigDecimal())
 }

--- a/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
@@ -9,9 +9,116 @@ plugins {
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
+
+    `maven-publish`
+    signing
 }
 
 // libraries need 75% coverage at least
 scoverage {
     minimumRate.set(0.75.toBigDecimal())
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+tasks.jar {
+    manifest {
+        attributes(mapOf("Implementation-Title" to project.name,
+            "Implementation-Version" to project.version))
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>(name) {
+            from(components["java"])
+
+            versionMapping {
+                usage("java-api") {
+                    fromResolutionOf("runtimeClasspath")
+                }
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
+
+            repositories {
+
+                maven {
+                    name = "MavenCentral"
+                    url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
+
+                    credentials.username =
+                        System.getenv("MAVEN_CENTRAL_USERNAME")
+                            ?: findProperty("mavenCentralUsername").toString()
+
+                    credentials.password =
+                        System.getenv("MAVEN_CENTRAL_PASSWORD")
+                            ?: findProperty("mavenCentralPassword").toString()
+                }
+            }
+
+            pom {
+                name.set("ScalaQuest ${artifactId.capitalize()}")
+                description.set("The ${artifactId.capitalize()} module of the ScalaQuest Project.")
+                url.set("https://scalaquest.github.io/PPS-19-ScalaQuest")
+
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://github.com/scalaquest/PPS-19-ScalaQuest/blob/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("riccm")
+                        name.set("Riccardo Maldini")
+                        email.set("riccardo.maldini@gmail.com")
+                    }
+                    developer {
+                        id.set("riccm")
+                        name.set("Riccardo Maldini")
+                        email.set("riccardo.maldini@gmail.com")
+                    }
+                    developer {
+                        id.set("filin")
+                        name.set("Filippo Nardini")
+                        email.set("filippo.nardini@studio.unibo.it")
+                    }
+                    developer {
+                        id.set("frang")
+                        name.set("Francesco Gorini")
+                        email.set("francesco.gorini@studio.unibo.it")
+                    }
+                    developer {
+                        id.set("jacoc")
+                        name.set("Jacopo Corina")
+                        email.set("jacopo.corina@studio.unibo.it")
+                    }
+                    developer {
+                        id.set("thoma")
+                        name.set("Thomas Angelini")
+                        email.set("thomas.angelini@studio.unibo.it")
+                    }
+                }
+                scm {
+                    connection.set("git:git@github.com:scalaquest/PPS-19-ScalaQuest.git")
+                    developerConnection.set("git:ssh://git@github.com:scalaquest/PPS-19-ScalaQuest.git")
+                    url.set("https://github.com/scalaquest/PPS-19-ScalaQuest")
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingPassword = System.getenv("SIGNING_PASSWORD")
+        ?: findProperty("signingPassword")?.toString()
+    val signingKey = System.getenv("SIGNING_KEY")
+        ?: findProperty("signingKey")?.toString()
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications[name])
 }

--- a/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
@@ -85,11 +85,6 @@ publishing {
                         email.set("riccardo.maldini@gmail.com")
                     }
                     developer {
-                        id.set("riccm")
-                        name.set("Riccardo Maldini")
-                        email.set("riccardo.maldini@gmail.com")
-                    }
-                    developer {
                         id.set("filin")
                         name.set("Filippo Nardini")
                         email.set("filippo.nardini@studio.unibo.it")

--- a/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/scalaquest.libraries-conventions.gradle.kts
@@ -10,20 +10,23 @@ plugins {
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
 
+    // Apply maven-publish and signing to publish releasees to Maven Central.
     `maven-publish`
     signing
 }
 
-// libraries need 75% coverage at least
+// Libraries need 75% coverage at least.
 scoverage {
     minimumRate.set(0.75.toBigDecimal())
 }
 
+// Including sources and javadoc JARs is necessary to publish with Maven.
 java {
     withJavadocJar()
     withSourcesJar()
 }
 
+// Customizing the manifest file.
 tasks.jar {
     manifest {
         attributes(mapOf("Implementation-Title" to project.name,
@@ -31,6 +34,8 @@ tasks.jar {
     }
 }
 
+// Maven-publish plugin configuration. This creates a publication for each
+// library, named with the subproject's name.
 publishing {
     publications {
         create<MavenPublication>(name) {
@@ -45,8 +50,9 @@ publishing {
                 }
             }
 
+            // Repository credentials are set using environment variable, if available. If not
+            // available, credentials are searched into the project properties.
             repositories {
-
                 maven {
                     name = "MavenCentral"
                     url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
@@ -114,6 +120,8 @@ publishing {
     }
 }
 
+// Signing configuration. Ascii-armored private key and passphrase are set using environment
+// variables, when available. If not available, credentials are searched into the project properties.
 signing {
     val signingPassword = System.getenv("SIGNING_PASSWORD")
         ?: findProperty("signingPassword")?.toString()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,8 +3,5 @@ plugins {
 }
 
 dependencies {
-    // todo more module-specific dependencies here
-
-    // prolog
-    implementation("it.unibo.alice.tuprolog:tuprolog:3.3.0")
+    implementation("it.unibo.alice.tuprolog:tuprolog:_")
 }

--- a/examples/escape-room/build.gradle.kts
+++ b/examples/escape-room/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    // the example is based on the Scalaquest Shell version.
+    // the example is based on the ScalaQuest Cli module.
     implementation(project(":cli"))
 }
 

--- a/examples/poke-quest/build.gradle.kts
+++ b/examples/poke-quest/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    // the example is based on the Scalaquest Shell version.
+    // the example is based on the ScalaQuest Cli module.
     implementation(project(":cli"))
 }
 

--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,7 @@
 
 plugin.io.gitlab.arturbosch.detekt=1.15.0
 ##                     # available=1.16.0-RC1
+##                     # available=1.16.0-RC2
 
 plugin.org.sonarqube=3.1.1
 
@@ -15,12 +16,22 @@ version.com.diffplug.spotless..spotless-plugin-gradle=5.10.2
 version.com.github.julien-truffaut..monocle-core_2.13=2.1.0
 ##                                        # available=2.2.0-M1
 ##                                        # available=3.0.0-M0a
+##                                        # available=3.0.0-M1
+##                                        # available=3.0.0-M2
+##                                        # available=3.0.0-M3
 
 version.com.github.julien-truffaut..monocle-macro_2.13=2.1.0
 ##                                         # available=2.2.0-M1
 ##                                         # available=3.0.0-M0a
+##                                         # available=3.0.0-M1
+##                                         # available=3.0.0-M2
+##                                         # available=3.0.0-M3
 
 version.com.github.maiflai..gradle-scalatest=0.30
+
+version.dev.zio..zio-test-junit_2.13=1.0.4-2
+
+version.dev.zio..zio-test_2.13=1.0.4-2
 
 version.dev.zio..zio_2.13=1.0.4
 ##            # available=1.0.4-1
@@ -37,12 +48,5 @@ version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 version.org.scala-lang..scala-library=2.13.5
 
 version.org.scalatest..scalatest_2.13=3.2.5
-##                        # available=3.2.4-M1
 ##                        # available=3.3.0-SNAP2
 ##                        # available=3.3.0-SNAP3
-
-version.org.sonarsource.scanner.gradle..sonarqube-gradle-plugin=3.1.1
-
-version.dev.zio..zio-test_2.13=1.0.4-2
-
-version.dev.zio..zio-test-junit_2.13=1.0.4-2

--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,7 @@
 
 plugin.io.gitlab.arturbosch.detekt=1.15.0
 ##                     # available=1.16.0-RC1
+##                     # available=1.16.0-RC2
 
 plugin.org.sonarqube=3.1.1
 
@@ -15,12 +16,20 @@ version.com.diffplug.spotless..spotless-plugin-gradle=5.10.2
 version.com.github.julien-truffaut..monocle-core_2.13=2.1.0
 ##                                        # available=2.2.0-M1
 ##                                        # available=3.0.0-M0a
+##                                        # available=3.0.0-M1
+##                                        # available=3.0.0-M2
 
 version.com.github.julien-truffaut..monocle-macro_2.13=2.1.0
 ##                                         # available=2.2.0-M1
 ##                                         # available=3.0.0-M0a
+##                                         # available=3.0.0-M1
+##                                         # available=3.0.0-M2
 
 version.com.github.maiflai..gradle-scalatest=0.30
+
+version.dev.zio..zio-test-junit_2.13=1.0.4-2
+
+version.dev.zio..zio-test_2.13=1.0.4-2
 
 version.dev.zio..zio_2.13=1.0.4
 ##            # available=1.0.4-1
@@ -30,34 +39,15 @@ version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 
+version.it.unibo.alice.tuprolog..tuprolog=3.3.0
+
 version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
-##                                               # available=0.2.3-dev01-6f23ea8
-##                                               # available=0.2.3-dev01-5b21a10
-##                                               # available=0.2.3-dev02-668abeb
-##                                               # available=0.2.3-dev02-6e25fee
-##                                               # available=0.2.3-dev02-5fe3322
-##                                               # available=0.2.3-dev03-54802b0
-##                                               # available=0.2.3-dev03-3a2bc63
-##                                               # available=0.2.3-dev04-44b3aff
-##                                               # available=0.2.3-dev04-5538fbe
-##                                               # available=0.2.3-dev05-154bcf0
-##                                               # available=0.2.3-dev05-4fe4749
-##                                               # available=0.2.3-dev06-1d3780f
-##                                               # available=0.2.3-dev06-6b47ae5
-##                                               # available=0.2.3-dev07-c4a8f67
-##                                               # available=0.2.3-dev07-11ef977
 
 version.org.danilopianini..publish-on-central=0.4.2
 
 version.org.scala-lang..scala-library=2.13.4
+##                        # available=2.13.5
 
 version.org.scalatest..scalatest_2.13=3.2.5
-##                        # available=3.2.4-M1
 ##                        # available=3.3.0-SNAP2
 ##                        # available=3.3.0-SNAP3
-
-version.org.sonarsource.scanner.gradle..sonarqube-gradle-plugin=3.1.1
-
-version.dev.zio..zio-test_2.13=1.0.4-2
-
-version.dev.zio..zio-test-junit_2.13=1.0.4-2

--- a/versions.properties
+++ b/versions.properties
@@ -43,8 +43,6 @@ version.it.unibo.alice.tuprolog..tuprolog=3.3.0
 
 version.org.danilopianini..git-sensitive-semantic-versioning=0.2.3
 
-version.org.danilopianini..publish-on-central=0.4.2
-
 version.org.scala-lang..scala-library=2.13.4
 ##                        # available=2.13.5
 


### PR DESCRIPTION
This is an attempt to configure the project in order to automatically release our libraries also to the Maven Central Repository. We started the iter at the start of the project basically (see the ticket [here](https://issues.sonatype.org/browse/OSSRH-63868?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)), but we leave it as a secondary task, giving priority to other structural ones. I have just tried to generate a release from local, and it should be available soon (check [here](https://search.maven.org), it should appear searching our libraries).

The CI should be tested, anyway. Do not close the PR until testing is finished.