### PR TITLE
Bootstrapped dependency

### DIFF
--- a/examples/wizard-quest/README.md
+++ b/examples/wizard-quest/README.md
@@ -2,7 +2,8 @@
 
 WizardQuest is the last example given for the project. This makes use of
 custom `Item`s and a custom `Ground`, showing the potentiality of the last
-construct, mainly.
+construct, mainly. In addition, the examples imports che `cli` dependency
+from Maven Central, showing how to use it.
 
 You can find more details about the example, and a set of instructions to complete
 the story in this [appendix file](https://scalaquest.github.io/Reports/appendix/appendix.html).

--- a/examples/wizard-quest/build.gradle.kts
+++ b/examples/wizard-quest/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    // the example is based on the Scalaquest Shell version.
-    implementation(project(":cli"))
+    // the example is based on the Scalaquest Shell version, imported from Maven Central.
+    implementation("io.github.scalaquest:cli:0.3.1")
 }
 
 application {


### PR DESCRIPTION
This is an attempt to use, inside the WizardQuest example, the `cli` dependency from Maven Central, instead of building the one from the project. This is useful as a further correctness check. I've set the version to 0.3.1, but it should be set at 0.4.1 as soon as it will be available on Central.