### PR TITLE
Annotate tag on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,15 @@ jobs:
           ./gradlew :core:generateVersionFile
           echo "RELEASE_VERSION=$(cat ./core/build/version)" >> $GITHUB_ENV
 
+        # It is necessary to manually setting the tag, as simply creating a release generates a
+        # lightweight tag, making the gitSemVer plugin not working properly.
+      - name: Add tag
+        run: |
+          git config user.name releaserbot
+          git config user.email github-actions@github.com
+          git tag ${{ env.RELEASE_VERSION }} -a -m "Release ${{ env.RELEASE_VERSION }}"
+          git push --follow-tags
+
       - name: Create release
         id: create-release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Push Scaladoc to gh-pages
         run: |
           rm -rf gh-pages/{scaladoc,coverage}
-          mkdir gh-pages/{scaladoc,coverage} -p
+          mkdir gh-pages/{scaladoc,coverage}
 
           mv core/build/docs/scaladoc gh-pages/scaladoc/core
           mv cli/build/docs/scaladoc gh-pages/scaladoc/cli


### PR DESCRIPTION
This is another thing I missed in #123, pardon. Using directly `actions/create-release@v1` to generate the tag is fancy as it creates a small changelog automatically, but it has the problem that creates a lightweight tag, making gitSemVer not working properly. This solves the issue.