### PR TITLE
Release 0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -130,6 +132,17 @@ jobs:
             ./cli/build/libs
             ./core/build/libs
 
+      - name: Create "merge into dev" pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: main
+          base: dev
+          title: Merge main into dev branch
+          body: |
+            This PR merges the main branch back into dev. This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates, are also present on the dev branch.
+
   MavenDeploy:
     needs: Tag
     runs-on: ubuntu-18.04
@@ -137,6 +150,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -174,6 +189,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,15 @@ jobs:
           ./gradlew :core:generateVersionFile
           echo "RELEASE_VERSION=$(cat ./core/build/version)" >> $GITHUB_ENV
 
+        # It is necessary to manually setting the tag, as simply creating a release generates a
+        # lightweight tag, making the gitSemVer plugin not working properly.
+      - name: Add tag
+        run: |
+          git config user.name releaserbot
+          git config user.email github-actions@github.com
+          git tag ${{ env.RELEASE_VERSION }} -a -m "Release ${{ env.RELEASE_VERSION }}"
+          git push --follow-tags
+
       - name: Create release
         id: create-release
         uses: actions/create-release@v1
@@ -223,7 +232,7 @@ jobs:
       - name: Push Scaladoc to gh-pages
         run: |
           rm -rf gh-pages/{scaladoc,coverage}
-          mkdir gh-pages/{scaladoc,coverage} -p
+          mkdir gh-pages/{scaladoc,coverage}
 
           mv core/build/docs/scaladoc gh-pages/scaladoc/core
           mv cli/build/docs/scaladoc gh-pages/scaladoc/cli

--- a/examples/wizard-quest/README.md
+++ b/examples/wizard-quest/README.md
@@ -2,7 +2,8 @@
 
 WizardQuest is the last example given for the project. This makes use of
 custom `Item`s and a custom `Ground`, showing the potentiality of the last
-construct, mainly.
+construct, mainly. In addition, the examples imports che `cli` dependency
+from Maven Central, showing how to use it.
 
 You can find more details about the example, and a set of instructions to complete
 the story in this [appendix file](https://scalaquest.github.io/Reports/appendix/appendix.html).

--- a/examples/wizard-quest/build.gradle.kts
+++ b/examples/wizard-quest/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    // the example is based on the Scalaquest Shell version.
-    implementation(project(":cli"))
+    // the example is based on the Scalaquest Shell version, imported from Maven Central.
+    implementation("io.github.scalaquest:cli:0.3.1")
 }
 
 application {


### PR DESCRIPTION
This is a further minor release, with mainly some fixes done in the release workflow. It should represent the latest final stable version for ScalaQuest, the mic-check, a step behind release 1.0.0.
The release is useful in particular to update properly the bootstrapped dependency to a full-working version, after publishing on Maven Central.