### PR TITLE
Bootstrap dependency with refreshVersion

### DIFF
--- a/examples/wizard-quest/build.gradle.kts
+++ b/examples/wizard-quest/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     // the example is based on the Scalaquest Shell version, imported from Maven Central.
-    implementation("io.github.scalaquest:cli:0.3.1")
+    implementation("io.github.scalaquest:cli:_")
 }
 
 application {

--- a/versions.properties
+++ b/versions.properties
@@ -8,6 +8,7 @@
 plugin.io.gitlab.arturbosch.detekt=1.15.0
 ##                     # available=1.16.0-RC1
 ##                     # available=1.16.0-RC2
+##                     # available=1.16.0-RC3
 
 plugin.org.sonarqube=3.1.1
 
@@ -38,6 +39,8 @@ version.dev.zio..zio_2.13=1.0.4
 ##            # available=1.0.4-2
 
 version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
+
+version.io.github.scalaquest..cli=0.3.1
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 

--- a/versions.properties
+++ b/versions.properties
@@ -40,7 +40,7 @@ version.dev.zio..zio_2.13=1.0.4
 
 version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
 
-version.io.github.scalaquest..cli=0.3.1
+version.io.github.scalaquest..cli=0.4.2
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
 


### PR DESCRIPTION
This is the final step, importing the latest version of CLI from Maven into the WizardQuest example, and linking it to refreshVersions plugin