### PR TITLE
Upgrade gradle-scalatest from 0.30 to 0.31

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -28,7 +28,7 @@ version.com.github.julien-truffaut..monocle-macro_2.13=2.1.0
 ##                                         # available=3.0.0-M2
 ##                                         # available=3.0.0-M3
 
-version.com.github.maiflai..gradle-scalatest=0.30
+version.com.github.maiflai..gradle-scalatest=0.31
 
 version.dev.zio..zio-test-junit_2.13=1.0.4-2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.