### PR TITLE
Upgrade sonarqube from 3.1.1 to 3.2.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@ plugin.io.gitlab.arturbosch.detekt=1.15.0
 ##                     # available=1.16.0-RC2
 ##                     # available=1.16.0-RC3
 
-plugin.org.sonarqube=3.1.1
+plugin.org.sonarqube=3.2.0
 
 version.com.diffplug.spotless..spotless-plugin-gradle=5.11.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.