### PR TITLE
Upgrade detekt-formatting from 1.15.0-RC1 to 1.16.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -42,7 +42,7 @@ version.gradle.plugin.org.scoverage..gradle-scoverage=5.0.0
 
 version.io.github.scalaquest..cli=0.4.2
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0-RC1
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.16.0
 
 version.it.unibo.alice.tuprolog..tuprolog=3.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.